### PR TITLE
fix: use alpine:3.21 for runner pod to fix PSA non-numeric user error

### DIFF
--- a/pkg/k8s/run.go
+++ b/pkg/k8s/run.go
@@ -52,17 +52,14 @@ func RunWorkflowPod(ctx context.Context, client *Client, namespace, name string,
 			RestartPolicy: corev1.RestartPolicyNever,
 			Containers: []corev1.Container{
 				{
-					Name:  "curl",
-					Image: "curlimages/curl:latest",
-					Command: []string{
-						"curl", "-sf",
-						"--retry", "5",
-						"--retry-connrefused",
-						"--retry-delay", "1",
-						"-X", "POST",
-						"-H", "Content-Type: application/json",
-						"-d", payload,
-						svcURL,
+					Name:  "trigger",
+					Image: "alpine:3.21",
+					Command: []string{"sh", "-c",
+						`for i in 1 2 3 4 5; do wget -q -O - --post-data "$PAYLOAD" --header 'Content-Type: application/json' "$TARGET_URL" && exit 0; sleep 1; done; exit 1`,
+					},
+					Env: []corev1.EnvVar{
+						{Name: "PAYLOAD", Value: payload},
+						{Name: "TARGET_URL", Value: svcURL},
 					},
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{


### PR DESCRIPTION
## Summary
- Replace `curlimages/curl:latest` with `alpine:3.21` for wf_run trigger pods
- curlimages/curl has `USER curl_user` (non-numeric) which causes PSA restricted rejection: "container has runAsNonRoot and image has non-numeric user"
- Use BusyBox wget with retry loop instead of curl
- Pass payload via env vars to avoid shell injection

## Test plan
- [x] `go test -count=1 ./...` — all packages pass
- [ ] E2E: `wf_run` on eastus with PSA restricted namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)