### PR TITLE
refactor: replace trigger pod with K8s API service proxy for wf_run

### DIFF
--- a/pkg/k8s/run.go
+++ b/pkg/k8s/run.go
@@ -1,175 +1,39 @@
 package k8s
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"time"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/watch"
 )
 
-// RunWorkflowPod creates an ephemeral curl pod that POSTs the given input to
-// http://<name>.<namespace>.svc:8080/run, waits for it to complete, captures
-// stdout as the JSON output, and deletes the pod on return. The pod is always
-// deleted even if the run fails. Returns the pod name, the raw JSON output
-// bytes, and any error.
+// RunWorkflow triggers a deployed workflow by POSTing to its /run endpoint
+// via the Kubernetes API service proxy. This routes the request through the
+// API server directly to the workflow service, eliminating the need for
+// ephemeral trigger pods, container images, NetworkPolicy rules for triggers,
+// and kube-router ipset sync races.
 //
-// The curl command uses --retry to tolerate kube-router NetworkPolicy ipset
-// sync races (same pattern as the CLI RunWorkflow helper).
-func RunWorkflowPod(ctx context.Context, client *Client, namespace, name string, input json.RawMessage) (string, json.RawMessage, error) {
-	svcURL := fmt.Sprintf("http://%s.%s.svc:8080/run", name, namespace)
-	podName := fmt.Sprintf("tntc-run-%s-%d", name, time.Now().UnixMilli())
-
-	// Default to empty JSON object if no input provided.
-	// Limit payload size to 1MB to avoid exceeding container arg limits.
-	const maxPayloadBytes = 1 << 20 // 1MB
-	payload := `{}`
+// The API server proxies: POST /api/v1/namespaces/{ns}/services/{svc}:8080/proxy/run
+func RunWorkflow(ctx context.Context, client *Client, namespace, name string, input json.RawMessage) (json.RawMessage, error) {
+	payload := []byte(`{}`)
 	if len(input) > 0 {
-		if len(input) > maxPayloadBytes {
-			return "", nil, fmt.Errorf("payload too large (%d bytes); maximum is %d bytes", len(input), maxPayloadBytes)
-		}
-		payload = string(input)
+		payload = input
 	}
 
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				ManagedByLabel:           ManagedByValue,
-				"tentacular/run-target":  name,
-				"tentacular.dev/role":    "trigger",
-			},
-		},
-		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyNever,
-			Containers: []corev1.Container{
-				{
-					Name:  "trigger",
-					Image: "alpine:3.21",
-					Command: []string{"sh", "-c",
-						`for i in 1 2 3 4 5; do wget -q -O - --post-data "$PAYLOAD" --header 'Content-Type: application/json' "$TARGET_URL" && exit 0; sleep 1; done; exit 1`,
-					},
-					Env: []corev1.EnvVar{
-						{Name: "PAYLOAD", Value: payload},
-						{Name: "TARGET_URL", Value: svcURL},
-					},
-					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-							corev1.ResourceCPU:    resource.MustParse("100m"),
-						},
-					},
-					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: boolPtr(false),
-						RunAsNonRoot:             boolPtr(true),
-						RunAsUser:                int64Ptr(65534),
-						ReadOnlyRootFilesystem:   boolPtr(true),
-						SeccompProfile: &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
-						},
-						Capabilities: &corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-						},
-					},
-				},
-			},
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: boolPtr(true),
-				RunAsUser:    int64Ptr(65534),
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
-			},
-		},
-	}
+	proxyPath := fmt.Sprintf("/api/v1/namespaces/%s/services/%s:8080/proxy/run", namespace, name)
 
-	created, err := client.Clientset.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+	raw, err := client.Clientset.CoreV1().RESTClient().
+		Post().
+		AbsPath(proxyPath).
+		SetHeader("Content-Type", "application/json").
+		Body(payload).
+		DoRaw(ctx)
 	if err != nil {
-		return "", nil, fmt.Errorf("create runner pod: %w", err)
+		return nil, fmt.Errorf("trigger workflow %s/%s: %w", namespace, name, err)
 	}
 
-	// Always clean up the trigger pod, even on error
-	defer func() {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		_ = client.Clientset.CoreV1().Pods(namespace).Delete(cleanupCtx, podName, metav1.DeleteOptions{})
-	}()
-
-	// If the pod already completed before we started watching, skip watch
-	if created.Status.Phase != corev1.PodSucceeded && created.Status.Phase != corev1.PodFailed {
-		watcher, err := client.Clientset.CoreV1().Pods(namespace).Watch(ctx, metav1.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector("metadata.name", podName).String(),
-		})
-		if err != nil {
-			return podName, nil, fmt.Errorf("watch runner pod: %w", err)
-		}
-		defer watcher.Stop()
-
-	watchLoop:
-		for {
-			select {
-			case <-ctx.Done():
-				return podName, nil, fmt.Errorf("context cancelled waiting for runner pod: %w", ctx.Err())
-			case event, ok := <-watcher.ResultChan():
-				if !ok {
-					break watchLoop
-				}
-				if event.Type == watch.Error {
-					return podName, nil, fmt.Errorf("watch error for runner pod %q", podName)
-				}
-				p, podOK := event.Object.(*corev1.Pod)
-				if !podOK {
-					continue
-				}
-				if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
-					break watchLoop
-				}
-			}
-		}
+	if len(raw) == 0 {
+		return json.RawMessage(`null`), nil
 	}
 
-	// Fetch final pod state to check phase
-	finalPod, err := client.Clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
-	if err != nil {
-		return podName, nil, fmt.Errorf("get runner pod status: %w", err)
-	}
-
-	// Capture stdout logs
-	logStream, err := client.Clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{}).Stream(ctx)
-	if err != nil {
-		return podName, nil, fmt.Errorf("read runner pod logs: %w", err)
-	}
-	defer logStream.Close()
-
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, logStream); err != nil {
-		return podName, nil, fmt.Errorf("copy runner pod output: %w", err)
-	}
-
-	if finalPod.Status.Phase == corev1.PodFailed {
-		return podName, nil, fmt.Errorf("workflow run failed: %s", buf.String())
-	}
-
-	output := json.RawMessage(buf.Bytes())
-	if len(output) == 0 {
-		output = json.RawMessage(`null`)
-	}
-
-	return podName, output, nil
-}
-
-func boolPtr(b bool) *bool {
-	return &b
-}
-
-func int64Ptr(i int64) *int64 {
-	return &i
+	return json.RawMessage(raw), nil
 }

--- a/pkg/k8s/run_test.go
+++ b/pkg/k8s/run_test.go
@@ -3,226 +3,116 @@ package k8s
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
-	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
-func newRunTestClient() *Client {
-	return &Client{
-		Clientset: fake.NewSimpleClientset(),
-		Config:    &rest.Config{Host: "https://test:6443"},
+// TestRunWorkflowUsesServiceProxy verifies that RunWorkflow calls the
+// K8s API service proxy path and returns the response body.
+func TestRunWorkflowUsesServiceProxy(t *testing.T) {
+	// Start a fake API server that captures the proxy request
+	var capturedPath string
+	var capturedMethod string
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedMethod = r.Method
+		capturedBody, _ = readAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"result":"ok","stories":10}`))
+	}))
+	defer server.Close()
+
+	clientset, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &Client{Clientset: clientset, Config: &rest.Config{Host: server.URL}}
+
+	output, err := RunWorkflow(context.Background(), client, "tent-dev", "hn-digest", json.RawMessage(`{"filter":"ai"}`))
+	if err != nil {
+		t.Fatalf("RunWorkflow error: %v", err)
+	}
+
+	// Verify the proxy path
+	expectedPath := "/api/v1/namespaces/tent-dev/services/hn-digest:8080/proxy/run"
+	if capturedPath != expectedPath {
+		t.Errorf("expected path %q, got %q", expectedPath, capturedPath)
+	}
+	if capturedMethod != "POST" {
+		t.Errorf("expected POST, got %s", capturedMethod)
+	}
+	if string(capturedBody) != `{"filter":"ai"}` {
+		t.Errorf("expected payload {\"filter\":\"ai\"}, got %s", capturedBody)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if result["result"] != "ok" {
+		t.Errorf("expected result=ok, got %v", result["result"])
 	}
 }
 
-func managedNsForRun(name string) *corev1.Namespace {
-	return &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{ManagedByLabel: ManagedByValue},
-		},
+// TestRunWorkflowDefaultPayload verifies that nil input sends an empty JSON object.
+func TestRunWorkflowDefaultPayload(t *testing.T) {
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = readAll(r.Body)
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	clientset, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &Client{Clientset: clientset, Config: &rest.Config{Host: server.URL}}
+
+	_, err = RunWorkflow(context.Background(), client, "ns", "wf", nil)
+	if err != nil {
+		t.Fatalf("RunWorkflow error: %v", err)
+	}
+
+	if string(capturedBody) != `{}` {
+		t.Errorf("expected default payload {}, got %s", capturedBody)
 	}
 }
 
-// TestRunWorkflowPodCreatesWithCorrectLabels verifies the trigger pod is created
-// with all required labels before the watch blocks.
-func TestRunWorkflowPodCreatesWithCorrectLabels(t *testing.T) {
-	client := newRunTestClient()
-	bgCtx := context.Background()
+// TestRunWorkflowProxyError verifies that API server errors are propagated.
+func TestRunWorkflowProxyError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		w.Write([]byte(`{"message":"service unavailable"}`))
+	}))
+	defer server.Close()
 
-	client.Clientset.CoreV1().Namespaces().Create(bgCtx, managedNsForRun("label-ns"), metav1.CreateOptions{})
+	clientset, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &Client{Clientset: clientset, Config: &rest.Config{Host: server.URL}}
 
-	runCtx, runCancel := context.WithTimeout(bgCtx, 5*time.Second)
-	defer runCancel()
+	_, err = RunWorkflow(context.Background(), client, "ns", "wf", nil)
+	if err == nil {
+		t.Fatal("expected error for 502 response")
+	}
+}
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		RunWorkflowPod(runCtx, client, "label-ns", "my-workflow", json.RawMessage(`{"x":1}`))
-	}()
-
-	// Poll for the pod to appear in the fake client
-	var foundPod *corev1.Pod
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		pods, _ := client.Clientset.CoreV1().Pods("label-ns").List(bgCtx, metav1.ListOptions{})
-		if len(pods.Items) > 0 {
-			foundPod = &pods.Items[0]
+func readAll(r interface{ Read([]byte) (int, error) }) ([]byte, error) {
+	var buf []byte
+	tmp := make([]byte, 1024)
+	for {
+		n, err := r.Read(tmp)
+		buf = append(buf, tmp[:n]...)
+		if err != nil {
 			break
 		}
-		time.Sleep(5 * time.Millisecond)
 	}
-
-	runCancel()
-	<-done
-
-	if foundPod == nil {
-		t.Fatal("trigger pod was not created in the fake client")
-	}
-
-	if foundPod.Labels[ManagedByLabel] != ManagedByValue {
-		t.Errorf("missing managed-by label: %v", foundPod.Labels)
-	}
-	if foundPod.Labels["tentacular/run-target"] != "my-workflow" {
-		t.Errorf("missing run-target label: got %q", foundPod.Labels["tentacular/run-target"])
-	}
-	if foundPod.Labels["tentacular.dev/role"] != "trigger" {
-		t.Errorf("missing role label: got %q", foundPod.Labels["tentacular.dev/role"])
-	}
-	if foundPod.Spec.RestartPolicy != corev1.RestartPolicyNever {
-		t.Errorf("expected RestartPolicyNever, got %q", foundPod.Spec.RestartPolicy)
-	}
-}
-
-// TestRunWorkflowPodRunAsUser verifies that the trigger pod has RunAsUser: 65534 set
-// at the container level for PSA restricted compliance.
-func TestRunWorkflowPodRunAsUser(t *testing.T) {
-	client := newRunTestClient()
-	bgCtx := context.Background()
-
-	client.Clientset.CoreV1().Namespaces().Create(bgCtx, managedNsForRun("run-user-ns"), metav1.CreateOptions{})
-
-	runCtx, runCancel := context.WithTimeout(bgCtx, 5*time.Second)
-	defer runCancel()
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		RunWorkflowPod(runCtx, client, "run-user-ns", "wf", nil)
-	}()
-
-	var foundPod *corev1.Pod
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		pods, _ := client.Clientset.CoreV1().Pods("run-user-ns").List(bgCtx, metav1.ListOptions{})
-		if len(pods.Items) > 0 {
-			foundPod = &pods.Items[0]
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-
-	runCancel()
-	<-done
-
-	if foundPod == nil {
-		t.Fatal("trigger pod was not created in the fake client")
-	}
-
-	if len(foundPod.Spec.Containers) == 0 {
-		t.Fatal("expected at least one container")
-	}
-	csc := foundPod.Spec.Containers[0].SecurityContext
-	if csc == nil {
-		t.Fatal("container security context should not be nil")
-	}
-
-	if csc.RunAsUser == nil {
-		t.Error("RunAsUser should be set (expected 65534)")
-	} else if *csc.RunAsUser != 65534 {
-		t.Errorf("RunAsUser should be 65534 (nobody), got %d", *csc.RunAsUser)
-	}
-}
-
-// TestRunWorkflowPodSecurityContext verifies that the trigger pod has security context set.
-func TestRunWorkflowPodSecurityContext(t *testing.T) {
-	client := newRunTestClient()
-	bgCtx := context.Background()
-
-	client.Clientset.CoreV1().Namespaces().Create(bgCtx, managedNsForRun("sec-ns"), metav1.CreateOptions{})
-
-	runCtx, runCancel := context.WithTimeout(bgCtx, 5*time.Second)
-	defer runCancel()
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		RunWorkflowPod(runCtx, client, "sec-ns", "wf", nil)
-	}()
-
-	var foundPod *corev1.Pod
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		pods, _ := client.Clientset.CoreV1().Pods("sec-ns").List(bgCtx, metav1.ListOptions{})
-		if len(pods.Items) > 0 {
-			foundPod = &pods.Items[0]
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-
-	runCancel()
-	<-done
-
-	if foundPod == nil {
-		t.Fatal("trigger pod was not created in the fake client")
-	}
-
-	if foundPod.Spec.SecurityContext == nil {
-		t.Error("pod security context should not be nil")
-	}
-	if len(foundPod.Spec.Containers) == 0 {
-		t.Fatal("expected at least one container")
-	}
-	csc := foundPod.Spec.Containers[0].SecurityContext
-	if csc == nil {
-		t.Error("container security context should not be nil")
-		return
-	}
-	if csc.AllowPrivilegeEscalation == nil || *csc.AllowPrivilegeEscalation {
-		t.Error("AllowPrivilegeEscalation should be false")
-	}
-	if csc.RunAsNonRoot == nil || !*csc.RunAsNonRoot {
-		t.Error("RunAsNonRoot should be true")
-	}
-	if csc.RunAsUser == nil || *csc.RunAsUser != 65534 {
-		t.Errorf("RunAsUser should be 65534, got %v", csc.RunAsUser)
-	}
-	if csc.ReadOnlyRootFilesystem == nil || !*csc.ReadOnlyRootFilesystem {
-		t.Error("ReadOnlyRootFilesystem should be true")
-	}
-
-	psc := foundPod.Spec.SecurityContext
-	if psc.RunAsUser == nil || *psc.RunAsUser != 65534 {
-		t.Errorf("pod-level RunAsUser should be 65534, got %v", psc.RunAsUser)
-	}
-}
-
-// TestRunWorkflowPodContextCancellation verifies that cancelling the context
-// causes RunWorkflowPod to return promptly.
-func TestRunWorkflowPodContextCancellation(t *testing.T) {
-	client := newRunTestClient()
-	bgCtx := context.Background()
-
-	client.Clientset.CoreV1().Namespaces().Create(bgCtx, managedNsForRun("cancel-ns"), metav1.CreateOptions{})
-
-	runCtx, runCancel := context.WithTimeout(bgCtx, 5*time.Second)
-
-	done := make(chan error, 1)
-	go func() {
-		_, _, err := RunWorkflowPod(runCtx, client, "cancel-ns", "wf", nil)
-		done <- err
-	}()
-
-	// Cancel context after the pod is created
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		pods, _ := client.Clientset.CoreV1().Pods("cancel-ns").List(bgCtx, metav1.ListOptions{})
-		if len(pods.Items) > 0 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	runCancel()
-
-	select {
-	case <-done:
-		// returned promptly -- good
-	case <-time.After(3 * time.Second):
-		t.Error("RunWorkflowPod did not return after context cancellation")
-	}
+	return buf, nil
 }

--- a/pkg/tools/run.go
+++ b/pkg/tools/run.go
@@ -25,13 +25,12 @@ type WfRunResult struct {
 	Namespace  string          `json:"namespace"`
 	Output     json.RawMessage `json:"output"`
 	DurationMs int64           `json:"duration_ms"`
-	PodName    string          `json:"pod_name"`
 }
 
 func registerRunTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_run",
-		Description: "Trigger a deployed workflow by POSTing to its /run endpoint via an ephemeral in-cluster pod. Returns the JSON output from the workflow.",
+		Description: "Trigger a deployed workflow by POSTing to its /run endpoint via the Kubernetes API service proxy. Returns the JSON output from the workflow.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WfRunParams) (*mcp.CallToolResult, WfRunResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WfRunResult{}, err
@@ -57,7 +56,7 @@ func handleWfRun(ctx context.Context, client *k8s.Client, params WfRunParams) (W
 	defer cancel()
 
 	start := time.Now()
-	podName, output, err := k8s.RunWorkflowPod(runCtx, client, params.Namespace, params.Name, params.Input)
+	output, err := k8s.RunWorkflow(runCtx, client, params.Namespace, params.Name, params.Input)
 	if err != nil {
 		return WfRunResult{}, err
 	}
@@ -67,6 +66,5 @@ func handleWfRun(ctx context.Context, client *k8s.Client, params WfRunParams) (W
 		Namespace:  params.Namespace,
 		Output:     output,
 		DurationMs: time.Since(start).Milliseconds(),
-		PodName:    podName,
 	}, nil
 }

--- a/pkg/tools/run_test.go
+++ b/pkg/tools/run_test.go
@@ -2,12 +2,14 @@ package tools
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 
@@ -31,6 +33,30 @@ func newRunToolTestClient(namespaces ...string) *k8s.Client {
 	}
 }
 
+// newRunToolTestClientWithProxy creates a client backed by a real HTTP test
+// server so the K8s API service proxy path works in tests.
+func newRunToolTestClientWithProxy(t *testing.T, handler http.HandlerFunc, namespaces ...string) (*k8s.Client, *httptest.Server) {
+	t.Helper()
+	// Seed managed namespaces into the handler so namespace lookups work
+	mux := http.NewServeMux()
+	for _, name := range namespaces {
+		ns := name // capture
+		mux.HandleFunc("/api/v1/namespaces/"+ns, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"metadata":{"name":"` + ns + `","labels":{"app.kubernetes.io/managed-by":"tentacular"}}}`))
+		})
+	}
+	// Proxy endpoint
+	mux.HandleFunc("/api/v1/namespaces/", handler)
+
+	server := httptest.NewServer(mux)
+	clientset, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &k8s.Client{Clientset: clientset, Config: &rest.Config{Host: server.URL}}, server
+}
+
 // TestHandleWfRun_SystemNamespaceRejected verifies the guard rejects tentacular-system
 // before any K8s API call is made.
 func TestHandleWfRun_SystemNamespaceRejected(t *testing.T) {
@@ -49,7 +75,6 @@ func TestHandleWfRun_SystemNamespaceRejected(t *testing.T) {
 // TestHandleWfRun_UnmanagedNamespaceRejected verifies that an unmanaged namespace
 // is rejected by CheckManagedNamespace before the run starts.
 func TestHandleWfRun_UnmanagedNamespaceRejected(t *testing.T) {
-	// No namespaces pre-seeded, so "unmanaged-ns" does not exist and is unmanaged
 	client := newRunToolTestClient()
 	ctx := context.Background()
 
@@ -62,12 +87,11 @@ func TestHandleWfRun_UnmanagedNamespaceRejected(t *testing.T) {
 	}
 }
 
-// TestWfRunParams_TimeoutDefaults verifies timeout boundary logic via the params struct
-// (unit test of the timeout logic without invoking the full run).
+// TestWfRunParams_TimeoutDefaults verifies timeout boundary logic.
 func TestWfRunParams_TimeoutDefaults(t *testing.T) {
 	cases := []struct {
 		timeoutS int
-		wantCap  bool // true if we expect the 600s cap to apply
+		wantCap  bool
 	}{
 		{0, false},
 		{60, false},
@@ -79,7 +103,6 @@ func TestWfRunParams_TimeoutDefaults(t *testing.T) {
 
 	for _, tc := range cases {
 		params := WfRunParams{TimeoutS: tc.timeoutS}
-		// Replicate the clamping logic from handleWfRun
 		const defaultTimeout = 120
 		const maxTimeout = 600
 		result := defaultTimeout
@@ -102,77 +125,37 @@ func TestWfRunParams_TimeoutDefaults(t *testing.T) {
 }
 
 // TestHandleWfRun_ManagedNamespacePassesGuard verifies that a managed namespace
-// passes the guard check and enters the run (which will fail due to fake client
-// watch limitations, but the namespace guard and managed check pass).
+// passes the guard check and the run completes via the API service proxy.
 func TestHandleWfRun_ManagedNamespacePassesGuard(t *testing.T) {
-	client := newRunToolTestClient("user-ns")
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
+	client, server := newRunToolTestClientWithProxy(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"result":"ok"}`))
+	}, "user-ns")
+	defer server.Close()
 
-	// This will fail at RunWorkflowPod (watch/log limitation of fake client)
-	// but NOT at the guard or namespace check. Error is expected.
-	_, err := handleWfRun(ctx, client, WfRunParams{
+	ctx := context.Background()
+	result, err := handleWfRun(ctx, client, WfRunParams{
 		Namespace: "user-ns",
 		Name:      "my-wf",
-		TimeoutS:  0, // default
 	})
-	// The managed namespace check passed (no "not managed" error), so we
-	// expect either a context error or a runner pod error — not a guard error.
 	if err != nil {
-		errStr := err.Error()
-		if contains(errStr, "tentacular-system") || contains(errStr, "guard") {
-			t.Errorf("unexpected guard error (namespace check should pass for managed ns): %v", err)
-		}
-		// Any other error (context deadline, fake client limitation) is acceptable
-		t.Logf("expected non-guard error from fake client: %v", err)
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result.Output) != `{"result":"ok"}` {
+		t.Errorf("expected output {\"result\":\"ok\"}, got %s", result.Output)
+	}
+	if result.DurationMs < 0 {
+		t.Errorf("expected positive duration, got %d", result.DurationMs)
 	}
 }
 
-// TestHandleWfRun_TimeoutOverCap verifies that a timeout > 600 is capped at 600s.
-func TestHandleWfRun_TimeoutOverCap(t *testing.T) {
-	client := newRunToolTestClient("cap-ns")
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	// TimeoutS > 600 should be capped at 600s (but test will cancel via ctx)
-	_, err := handleWfRun(ctx, client, WfRunParams{
-		Namespace: "cap-ns",
-		Name:      "my-wf",
-		TimeoutS:  9999,
-	})
-	// Error expected (fake client won't complete the pod run)
-	// but it should NOT be a guard error
-	if err != nil && contains(err.Error(), "guard") {
-		t.Errorf("unexpected guard error: %v", err)
-	}
-}
-
-// TestHandleWfRun_ExplicitTimeout verifies an explicit valid timeout is accepted.
-func TestHandleWfRun_ExplicitTimeout(t *testing.T) {
-	client := newRunToolTestClient("timeout-ns")
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	_, err := handleWfRun(ctx, client, WfRunParams{
-		Namespace: "timeout-ns",
-		Name:      "my-wf",
-		TimeoutS:  30,
-	})
-	// Error expected from fake client limitations, not from timeout clamping
-	if err != nil {
-		t.Logf("expected error from fake client: %v", err)
-	}
-}
-
-// TestWfRunResult_Fields verifies the WfRunResult struct fields match what
-// handleWfRun sets.
+// TestWfRunResult_Fields verifies the WfRunResult struct fields.
 func TestWfRunResult_Fields(t *testing.T) {
 	result := WfRunResult{
 		Name:       "my-wf",
 		Namespace:  "user-ns",
 		Output:     []byte(`{"ok":true}`),
 		DurationMs: 1234,
-		PodName:    "tntc-run-my-wf-12345",
 	}
 	if result.Name != "my-wf" {
 		t.Errorf("expected name=my-wf, got %q", result.Name)
@@ -183,15 +166,4 @@ func TestWfRunResult_Fields(t *testing.T) {
 	if string(result.Output) != `{"ok":true}` {
 		t.Errorf("unexpected output: %s", result.Output)
 	}
-}
-
-func contains(s, sub string) bool {
-	return len(sub) == 0 || (len(s) >= len(sub) && func() bool {
-		for i := 0; i <= len(s)-len(sub); i++ {
-			if s[i:i+len(sub)] == sub {
-				return true
-			}
-		}
-		return false
-	}())
 }


### PR DESCRIPTION
## Summary
- Replace ephemeral curl trigger pods with K8s API service proxy for `wf_run`
- MCP server now calls `POST /api/v1/namespaces/{ns}/services/{svc}:8080/proxy/run` directly
- Net -276 lines removed

## What this eliminates
- Container image dependency (curlimages/curl, alpine) for wf_run
- Pod creation, watching, log capture, and cleanup code
- PSA security context boilerplate for trigger pods
- kube-router ipset sync race condition
- Trigger NetworkPolicy requirement for wf_run

## What still uses curl
- CronJob triggers (runs on schedule, no MCP server involvement)
- Proxy pre-warm initContainers

## RBAC requirement
- Add `services/proxy` to the MCP server ClusterRole (`create`, `get` verbs)

## Test plan
- [x] `go test -count=1 ./...` — all packages pass
- [ ] E2E: `wf_run` on eastus via API service proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)