### PR TITLE
fix: handle workflow error responses from API service proxy

### DIFF
--- a/pkg/k8s/run.go
+++ b/pkg/k8s/run.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 // RunWorkflow triggers a deployed workflow by POSTing to its /run endpoint
@@ -21,14 +23,29 @@ func RunWorkflow(ctx context.Context, client *Client, namespace, name string, in
 
 	proxyPath := fmt.Sprintf("/api/v1/namespaces/%s/services/%s:8080/proxy/run", namespace, name)
 
-	raw, err := client.Clientset.CoreV1().RESTClient().
+	result := client.Clientset.CoreV1().RESTClient().
 		Post().
 		AbsPath(proxyPath).
 		SetHeader("Content-Type", "application/json").
 		Body(payload).
-		DoRaw(ctx)
-	if err != nil {
+		Do(ctx)
+
+	// Get the raw response body regardless of HTTP status.
+	// The workflow engine returns error details in the body even on 500.
+	raw, rawErr := result.Raw()
+
+	// Check for transport-level errors (connection refused, timeout, etc.)
+	if err := result.Error(); err != nil {
+		// If we have a response body, return it alongside the error context.
+		// The body contains workflow execution details (errors, timing, etc.)
+		if len(raw) > 0 && isProxyResponseError(err) {
+			return json.RawMessage(raw), nil
+		}
 		return nil, fmt.Errorf("trigger workflow %s/%s: %w", namespace, name, err)
+	}
+
+	if rawErr != nil {
+		return nil, fmt.Errorf("read workflow response: %w", rawErr)
 	}
 
 	if len(raw) == 0 {
@@ -36,4 +53,14 @@ func RunWorkflow(ctx context.Context, client *Client, namespace, name string, in
 	}
 
 	return json.RawMessage(raw), nil
+}
+
+// isProxyResponseError returns true if the error is from the proxied backend
+// (e.g., the workflow returned 500) rather than a K8s API transport error.
+func isProxyResponseError(err error) bool {
+	if statusErr, ok := err.(*errors.StatusError); ok {
+		code := statusErr.ErrStatus.Code
+		return code >= 400 && code < 600
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- Capture workflow response body even when the engine returns HTTP 500
- The K8s API service proxy passes through the backend's status code, causing the REST client to treat it as an error and discard the body
- The body contains valuable execution details (node errors, timing data)
- Distinguish between transport errors (connection refused) and proxied backend errors (workflow 500)

## Test plan
- [x] `go test -count=1 ./...` — all packages pass
- [ ] E2E: `wf_run` returns workflow error details instead of opaque "unknown" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)