### PR TITLE
fix: use any type for wf_run output schema

### DIFF
--- a/pkg/tools/run.go
+++ b/pkg/tools/run.go
@@ -21,10 +21,10 @@ type WfRunParams struct {
 
 // WfRunResult is the result of wf_run.
 type WfRunResult struct {
-	Name       string          `json:"name"`
-	Namespace  string          `json:"namespace"`
-	Output     json.RawMessage `json:"output"`
-	DurationMs int64           `json:"duration_ms"`
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace"`
+	Output     any    `json:"output"`
+	DurationMs int64  `json:"duration_ms"`
 }
 
 func registerRunTools(srv *mcp.Server, client *k8s.Client) {
@@ -56,9 +56,17 @@ func handleWfRun(ctx context.Context, client *k8s.Client, params WfRunParams) (W
 	defer cancel()
 
 	start := time.Now()
-	output, err := k8s.RunWorkflow(runCtx, client, params.Namespace, params.Name, params.Input)
+	raw, err := k8s.RunWorkflow(runCtx, client, params.Namespace, params.Name, params.Input)
 	if err != nil {
 		return WfRunResult{}, err
+	}
+
+	// Unmarshal raw JSON into any so the MCP schema accepts any JSON type.
+	var output any
+	if len(raw) > 0 {
+		if jsonErr := json.Unmarshal(raw, &output); jsonErr != nil {
+			output = string(raw)
+		}
 	}
 
 	return WfRunResult{

--- a/pkg/tools/run_test.go
+++ b/pkg/tools/run_test.go
@@ -141,8 +141,12 @@ func TestHandleWfRun_ManagedNamespacePassesGuard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if string(result.Output) != `{"result":"ok"}` {
-		t.Errorf("expected output {\"result\":\"ok\"}, got %s", result.Output)
+	outputMap, ok := result.Output.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected output to be map, got %T", result.Output)
+	}
+	if outputMap["result"] != "ok" {
+		t.Errorf("expected result=ok, got %v", outputMap["result"])
 	}
 	if result.DurationMs < 0 {
 		t.Errorf("expected positive duration, got %d", result.DurationMs)
@@ -154,7 +158,7 @@ func TestWfRunResult_Fields(t *testing.T) {
 	result := WfRunResult{
 		Name:       "my-wf",
 		Namespace:  "user-ns",
-		Output:     []byte(`{"ok":true}`),
+		Output:     map[string]interface{}{"ok": true},
 		DurationMs: 1234,
 	}
 	if result.Name != "my-wf" {
@@ -163,7 +167,8 @@ func TestWfRunResult_Fields(t *testing.T) {
 	if result.DurationMs != 1234 {
 		t.Errorf("expected duration=1234, got %d", result.DurationMs)
 	}
-	if string(result.Output) != `{"ok":true}` {
-		t.Errorf("unexpected output: %s", result.Output)
+	outputMap, ok := result.Output.(map[string]interface{})
+	if !ok || outputMap["ok"] != true {
+		t.Errorf("unexpected output: %v", result.Output)
 	}
 }


### PR DESCRIPTION
## Summary
- Change `WfRunResult.Output` from `json.RawMessage` to `any`
- MCP SDK schema validation rejects `json.RawMessage` (typed as `["null", "array"]`) when the workflow returns an object
- Unmarshal raw JSON into `any` before returning

## Test plan
- [x] `go test -count=1 ./...` — all pass
- [ ] E2E: `wf_run` returns workflow output without schema error

🤖 Generated with [Claude Code](https://claude.com/claude-code)