### PR TITLE
fix: add context timeout to cron scheduler and update stale comments

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,7 +1,7 @@
 // Package scheduler provides an in-process cron scheduler for tentacular
 // workflows. Instead of creating CronJob+Pod+curl for each scheduled trigger,
-// the scheduler runs inside the MCP server and triggers workflows via the
-// Kubernetes API service proxy — the same path as wf_run.
+// the scheduler runs inside the MCP server and triggers workflows via direct
+// HTTP to the workflow's ClusterIP service — the same path as wf_run.
 package scheduler
 
 import (
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/robfig/cron/v3"
 
@@ -115,11 +116,14 @@ func (s *Scheduler) Entries() int {
 	return len(s.entries)
 }
 
-// trigger fires a workflow run via the API service proxy.
+// trigger fires a workflow run via direct HTTP to the workflow's ClusterIP
+// service. Uses a 120s context timeout matching the default wf_run timeout
+// to prevent goroutine leaks from hung workflows.
 func (s *Scheduler) trigger(namespace, name string) {
 	s.logger.Info("cron trigger firing", "workflow", namespace+"/"+name)
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
 	output, err := k8s.RunWorkflow(ctx, s.client, namespace, name, nil)
 	if err != nil {
 		s.logger.Error("cron trigger failed", "workflow", namespace+"/"+name, "error", err)

--- a/pkg/tools/run.go
+++ b/pkg/tools/run.go
@@ -30,7 +30,7 @@ type WfRunResult struct {
 func registerRunTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_run",
-		Description: "Trigger a deployed workflow by POSTing to its /run endpoint via the Kubernetes API service proxy. Returns the JSON output from the workflow.",
+		Description: "Trigger a deployed workflow by POSTing directly to its /run endpoint via HTTP. The MCP server connects to the workflow's ClusterIP service; NetworkPolicy allows ingress from tentacular-system via namespaceSelector. Returns the JSON output from the workflow.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WfRunParams) (*mcp.CallToolResult, WfRunResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WfRunResult{}, err


### PR DESCRIPTION
## Summary

- Add 120s context timeout to `scheduler.trigger()` to prevent goroutine leaks from hung workflows
- Update 3 stale "API service proxy" references to "direct HTTP" (including user-facing wf_run tool description)

## Test plan

- [x] `go test -count=1 ./...` -- all tests pass
- [ ] Deploy to eastus, verify cron triggers still fire

Generated with [Claude Code](https://claude.com/claude-code)