### PR TITLE
fix: eliminate hardcoded version and namespace strings

### DIFF
--- a/pkg/proxy/manifests.go
+++ b/pkg/proxy/manifests.go
@@ -9,6 +9,9 @@ import (
 )
 
 const (
+	// DefaultNamespace is the default namespace for the esm.sh module proxy.
+	DefaultNamespace = "tentacular-support"
+
 	// DefaultImage is the default esm.sh module proxy image.
 	// Pinned to match the CLI's tntc cluster install default (GenerateModuleProxyManifests).
 	DefaultImage = "ghcr.io/esm-dev/esm.sh:v136"

--- a/pkg/proxy/reconciler.go
+++ b/pkg/proxy/reconciler.go
@@ -29,7 +29,7 @@ type Reconciler struct {
 // NewReconciler creates a new proxy Reconciler.
 func NewReconciler(client *k8s.Client, opts Options, logger *slog.Logger) *Reconciler {
 	if opts.Namespace == "" {
-		opts.Namespace = "tentacular-support"
+		opts.Namespace = DefaultNamespace
 	}
 	interval := DefaultInterval
 	return &Reconciler{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/randybias/tentacular-mcp/pkg/proxy"
 	"github.com/randybias/tentacular-mcp/pkg/scheduler"
 	"github.com/randybias/tentacular-mcp/pkg/tools"
+	"github.com/randybias/tentacular-mcp/pkg/version"
 )
 
 // Server wraps the MCP server with K8s client and auth.
@@ -28,7 +29,7 @@ func New(client *k8s.Client, reconciler *proxy.Reconciler, sched *scheduler.Sche
 	mcpServer := mcp.NewServer(
 		&mcp.Implementation{
 			Name:    "tentacular-mcp",
-			Version: "0.1.0",
+			Version: version.Version,
 		},
 		&mcp.ServerOptions{
 			Instructions: "In-cluster MCP server for Kubernetes namespace lifecycle, credential management, workflow introspection, cluster operations, and module proxy management.",

--- a/pkg/tools/deploy.go
+++ b/pkg/tools/deploy.go
@@ -16,12 +16,13 @@ import (
 
 	"github.com/randybias/tentacular-mcp/pkg/guard"
 	"github.com/randybias/tentacular-mcp/pkg/k8s"
+	"github.com/randybias/tentacular-mcp/pkg/proxy"
 	"github.com/randybias/tentacular-mcp/pkg/scheduler"
 )
 
 // defaultProxyNamespace is the namespace where the esm.sh module proxy lives.
-// Can be overridden with the TENTACULAR_PROXY_NAMESPACE environment variable.
-const defaultProxyNamespace = "tentacular-support"
+// Uses the canonical default from the proxy package.
+var defaultProxyNamespace = proxy.DefaultNamespace
 
 const releaseLabelKey = "tentacular.io/release"
 


### PR DESCRIPTION
## Summary

- Wire `version.Version` (GoReleaser ldflags) into MCP server initialize response instead of hardcoded `"0.1.0"`
- Add `proxy.DefaultNamespace` constant, use it in reconciler.go and deploy.go instead of raw strings
- guard.go namespace hardcoding is intentional (security boundary) and left unchanged

## Test plan

- [x] `go test -count=1 ./...` -- all tests pass
- [ ] Deploy to eastus, verify MCP initialize reports correct version

Generated with [Claude Code](https://claude.com/claude-code)