### PR TITLE
feat: add ns_update tool for updating managed namespace metadata and quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ curl http://localhost:8080/healthz
 | `ns_delete` | Delete a managed namespace and all child resources. |
 | `ns_get` | Get namespace details including labels, annotations, quota summary, and limit range. |
 | `ns_list` | List all tentacular-managed namespaces. |
+| `ns_update` | Update labels, annotations, or resource quota preset on a managed namespace. |
 
 ### Credential Management
 

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -61,6 +61,7 @@ Every namespace-accepting tool correctly calls `guard.CheckNamespace()` before a
 | ns_delete | params.Name | YES |
 | ns_get | params.Name | YES |
 | ns_list | (none) | N/A - cluster-scoped |
+| ns_update | params.Name | YES |
 | cred_issue_token | params.Namespace | YES |
 | cred_kubeconfig | params.Namespace | YES |
 | cred_rotate | params.Namespace | YES |

--- a/openspec/specs/namespace-lifecycle/spec.md
+++ b/openspec/specs/namespace-lifecycle/spec.md
@@ -55,3 +55,26 @@ The system SHALL list all namespaces with the `app.kubernetes.io/managed-by: ten
 - **WHEN** the `ns_list` tool is called and no managed namespaces exist
 - **THEN** the system returns an empty list
 
+### Requirement: Update managed namespace
+The system SHALL update labels, annotations, and/or resource quota preset on a managed namespace. At least one update field must be provided. The system SHALL reject the operation if the namespace is not managed by tentacular, if the target namespace is in the protected set, or if the caller attempts to change the `app.kubernetes.io/managed-by` label. Label and annotation updates are additive (existing keys not listed are preserved).
+
+#### Scenario: Update labels on managed namespace
+- **WHEN** the `ns_update` tool is called with `name: "dev-alice"` and `labels: {"env": "staging"}`
+- **THEN** the system adds the `env=staging` label while preserving existing labels including `managed-by`
+
+#### Scenario: Update quota preset on managed namespace
+- **WHEN** the `ns_update` tool is called with `name: "dev-alice"` and `quota_preset: "large"`
+- **THEN** the system updates the `tentacular-quota` ResourceQuota to the `large` preset (CPU=8, Mem=16Gi, Pods=50)
+
+#### Scenario: Reject update on unmanaged namespace
+- **WHEN** the `ns_update` tool is called with a namespace that lacks the managed-by label
+- **THEN** the system returns an error indicating the namespace is not managed by tentacular
+
+#### Scenario: Reject when no update fields provided
+- **WHEN** the `ns_update` tool is called with only `name` and no labels, annotations, or quota_preset
+- **THEN** the system returns an error indicating at least one update field is required
+
+#### Scenario: Reject managed-by label change
+- **WHEN** the `ns_update` tool is called with `labels: {"app.kubernetes.io/managed-by": "other"}`
+- **THEN** the system returns an error indicating the managed-by label cannot be changed
+

--- a/pkg/k8s/quota.go
+++ b/pkg/k8s/quota.go
@@ -61,6 +61,38 @@ func CreateResourceQuota(ctx context.Context, client *Client, namespace, preset 
 	return nil
 }
 
+// UpdateResourceQuota updates the tentacular-quota ResourceQuota in the given
+// namespace to match the named preset.
+func UpdateResourceQuota(ctx context.Context, client *Client, namespace, preset string) error {
+	ctx, cancel := context.WithTimeout(ctx, Timeout)
+	defer cancel()
+
+	p, ok := quotaPresets[preset]
+	if !ok {
+		return fmt.Errorf("unknown quota preset %q (valid: small, medium, large)", preset)
+	}
+
+	quota, err := client.Clientset.CoreV1().ResourceQuotas(namespace).Get(ctx, "tentacular-quota", metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("resource quota not found in namespace %q; use ns_create to initialize", namespace)
+		}
+		return fmt.Errorf("get resource quota in namespace %q: %w", namespace, err)
+	}
+
+	quota.Spec.Hard = corev1.ResourceList{
+		corev1.ResourceLimitsCPU:    resource.MustParse(p.CPU),
+		corev1.ResourceLimitsMemory: resource.MustParse(p.Mem),
+		corev1.ResourcePods:         *resource.NewQuantity(p.Pods, resource.DecimalSI),
+	}
+
+	_, err = client.Clientset.CoreV1().ResourceQuotas(namespace).Update(ctx, quota, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("update resource quota in namespace %q: %w", namespace, err)
+	}
+	return nil
+}
+
 // CreateLimitRange creates a LimitRange in the given namespace with default
 // container resource requests and limits.
 func CreateLimitRange(ctx context.Context, client *Client, namespace string) error {

--- a/pkg/tools/namespace.go
+++ b/pkg/tools/namespace.go
@@ -2,12 +2,14 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/randybias/tentacular-mcp/pkg/guard"
 	"github.com/randybias/tentacular-mcp/pkg/k8s"
@@ -52,6 +54,20 @@ type NsGetResult struct {
 	Managed     bool              `json:"managed"`
 	Quota       *k8s.QuotaSummary      `json:"quota,omitempty"`
 	LimitRange  *k8s.LimitRangeSummary `json:"limitRange,omitempty"`
+}
+
+// NsUpdateParams are the parameters for ns_update.
+type NsUpdateParams struct {
+	Name        string            `json:"name" jsonschema:"Name of the namespace to update"`
+	Labels      map[string]string `json:"labels,omitempty" jsonschema:"Labels to add or update (existing labels not listed are preserved)"`
+	Annotations map[string]string `json:"annotations,omitempty" jsonschema:"Annotations to add or update (existing annotations not listed are preserved)"`
+	QuotaPreset string            `json:"quota_preset,omitempty" jsonschema:"New resource quota preset: small, medium, or large"`
+}
+
+// NsUpdateResult is the result of ns_update.
+type NsUpdateResult struct {
+	Name            string   `json:"name"`
+	Updated         []string `json:"updated"`
 }
 
 // NsListParams are the parameters for ns_list (empty).
@@ -109,6 +125,17 @@ func registerNamespaceTools(srv *mcp.Server, client *k8s.Client) {
 		Description: "List all namespaces managed by tentacular.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params NsListParams) (*mcp.CallToolResult, NsListResult, error) {
 		result, err := handleNsList(ctx, client)
+		return nil, result, err
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "ns_update",
+		Description: "Update labels, annotations, or resource quota preset on a managed namespace.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, params NsUpdateParams) (*mcp.CallToolResult, NsUpdateResult, error) {
+		if err := guard.CheckNamespace(params.Name); err != nil {
+			return nil, NsUpdateResult{}, err
+		}
+		result, err := handleNsUpdate(ctx, client, params)
 		return nil, result, err
 	})
 }
@@ -246,6 +273,65 @@ func handleNsGet(ctx context.Context, client *k8s.Client, params NsGetParams) (N
 	}
 
 	return result, nil
+}
+
+func handleNsUpdate(ctx context.Context, client *k8s.Client, params NsUpdateParams) (NsUpdateResult, error) {
+	if err := k8s.CheckManagedNamespace(ctx, client, params.Name); err != nil {
+		return NsUpdateResult{}, err
+	}
+
+	if len(params.Labels) == 0 && len(params.Annotations) == 0 && params.QuotaPreset == "" {
+		return NsUpdateResult{}, fmt.Errorf("at least one of labels, annotations, or quota_preset must be provided")
+	}
+
+	updated := []string{}
+
+	// Patch labels and/or annotations on the namespace via merge patch.
+	if len(params.Labels) > 0 || len(params.Annotations) > 0 {
+		// Prevent overwriting the managed-by label.
+		if v, ok := params.Labels[k8s.ManagedByLabel]; ok && v != k8s.ManagedByValue {
+			return NsUpdateResult{}, fmt.Errorf("cannot change the %s label", k8s.ManagedByLabel)
+		}
+
+		patchMeta := map[string]interface{}{}
+		if len(params.Labels) > 0 {
+			patchMeta["labels"] = params.Labels
+		}
+		if len(params.Annotations) > 0 {
+			patchMeta["annotations"] = params.Annotations
+		}
+		patchBody, err := json.Marshal(map[string]interface{}{"metadata": patchMeta})
+		if err != nil {
+			return NsUpdateResult{}, fmt.Errorf("marshal patch: %w", err)
+		}
+
+		_, err = client.Clientset.CoreV1().Namespaces().Patch(
+			ctx, params.Name, types.MergePatchType, patchBody, metav1.PatchOptions{},
+		)
+		if err != nil {
+			return NsUpdateResult{}, fmt.Errorf("patch namespace %q metadata: %w", params.Name, err)
+		}
+
+		if len(params.Labels) > 0 {
+			updated = append(updated, "labels")
+		}
+		if len(params.Annotations) > 0 {
+			updated = append(updated, "annotations")
+		}
+	}
+
+	// Update resource quota if requested.
+	if params.QuotaPreset != "" {
+		if err := k8s.UpdateResourceQuota(ctx, client, params.Name, params.QuotaPreset); err != nil {
+			return NsUpdateResult{}, err
+		}
+		updated = append(updated, "quota")
+	}
+
+	return NsUpdateResult{
+		Name:    params.Name,
+		Updated: updated,
+	}, nil
 }
 
 func handleNsList(ctx context.Context, client *k8s.Client) (NsListResult, error) {

--- a/pkg/tools/namespace_test.go
+++ b/pkg/tools/namespace_test.go
@@ -128,3 +128,152 @@ func TestNsList(t *testing.T) {
 		t.Errorf("expected 2 managed namespaces, got %d", len(result.Namespaces))
 	}
 }
+
+// --- ns_update tests ---
+
+func createManagedNsWithQuota(t *testing.T, client *k8s.Client, name string) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := handleNsCreate(ctx, client, NsCreateParams{Name: name, QuotaPreset: "small"})
+	if err != nil {
+		t.Fatalf("setup: create managed ns %q: %v", name, err)
+	}
+}
+
+func TestNsUpdateLabels(t *testing.T) {
+	client := newNsTestClient()
+	ctx := context.Background()
+	createManagedNsWithQuota(t, client, "upd-labels")
+
+	result, err := handleNsUpdate(ctx, client, NsUpdateParams{
+		Name:   "upd-labels",
+		Labels: map[string]string{"env": "staging"},
+	})
+	if err != nil {
+		t.Fatalf("handleNsUpdate: %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "labels" {
+		t.Errorf("expected updated=[labels], got %v", result.Updated)
+	}
+
+	// Verify label was applied.
+	ns, _ := k8s.GetNamespace(ctx, client, "upd-labels")
+	if ns.Labels["env"] != "staging" {
+		t.Errorf("expected label env=staging, got %q", ns.Labels["env"])
+	}
+	// Managed-by label must still be present.
+	if ns.Labels[k8s.ManagedByLabel] != k8s.ManagedByValue {
+		t.Error("managed-by label was lost after update")
+	}
+}
+
+func TestNsUpdateAnnotations(t *testing.T) {
+	client := newNsTestClient()
+	ctx := context.Background()
+	createManagedNsWithQuota(t, client, "upd-annot")
+
+	result, err := handleNsUpdate(ctx, client, NsUpdateParams{
+		Name:        "upd-annot",
+		Annotations: map[string]string{"team": "platform"},
+	})
+	if err != nil {
+		t.Fatalf("handleNsUpdate: %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "annotations" {
+		t.Errorf("expected updated=[annotations], got %v", result.Updated)
+	}
+
+	ns, _ := k8s.GetNamespace(ctx, client, "upd-annot")
+	if ns.Annotations["team"] != "platform" {
+		t.Errorf("expected annotation team=platform, got %q", ns.Annotations["team"])
+	}
+}
+
+func TestNsUpdateQuota(t *testing.T) {
+	client := newNsTestClient()
+	ctx := context.Background()
+	createManagedNsWithQuota(t, client, "upd-quota")
+
+	result, err := handleNsUpdate(ctx, client, NsUpdateParams{
+		Name:        "upd-quota",
+		QuotaPreset: "large",
+	})
+	if err != nil {
+		t.Fatalf("handleNsUpdate: %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "quota" {
+		t.Errorf("expected updated=[quota], got %v", result.Updated)
+	}
+
+	// Verify quota was updated to large preset (CPU=8).
+	quotas, _ := client.Clientset.CoreV1().ResourceQuotas("upd-quota").List(ctx, metav1.ListOptions{})
+	if len(quotas.Items) == 0 {
+		t.Fatal("no resource quota found")
+	}
+	cpu := quotas.Items[0].Spec.Hard[corev1.ResourceLimitsCPU]
+	if cpu.String() != "8" {
+		t.Errorf("expected CPU limit=8, got %q", cpu.String())
+	}
+}
+
+func TestNsUpdateAllFields(t *testing.T) {
+	client := newNsTestClient()
+	ctx := context.Background()
+	createManagedNsWithQuota(t, client, "upd-all")
+
+	result, err := handleNsUpdate(ctx, client, NsUpdateParams{
+		Name:        "upd-all",
+		Labels:      map[string]string{"env": "prod"},
+		Annotations: map[string]string{"owner": "alice"},
+		QuotaPreset: "medium",
+	})
+	if err != nil {
+		t.Fatalf("handleNsUpdate: %v", err)
+	}
+	if len(result.Updated) != 3 {
+		t.Errorf("expected 3 updated items, got %v", result.Updated)
+	}
+}
+
+func TestNsUpdateRejectsUnmanaged(t *testing.T) {
+	client := newNsTestClient()
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "foreign-ns"},
+	}
+	client.Clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+
+	_, err := handleNsUpdate(ctx, client, NsUpdateParams{
+		Name:   "foreign-ns",
+		Labels: map[string]string{"env": "test"},
+	})
+	if err == nil {
+		t.Fatal("expected error for unmanaged namespace, got nil")
+	}
+}
+
+func TestNsUpdateRejectsEmptyParams(t *testing.T) {
+	client := newNsTestClient()
+	ctx := context.Background()
+	createManagedNsWithQuota(t, client, "upd-empty")
+
+	_, err := handleNsUpdate(ctx, client, NsUpdateParams{Name: "upd-empty"})
+	if err == nil {
+		t.Fatal("expected error when no update fields provided, got nil")
+	}
+}
+
+func TestNsUpdateRejectsManagedByLabelChange(t *testing.T) {
+	client := newNsTestClient()
+	ctx := context.Background()
+	createManagedNsWithQuota(t, client, "upd-protect")
+
+	_, err := handleNsUpdate(ctx, client, NsUpdateParams{
+		Name:   "upd-protect",
+		Labels: map[string]string{k8s.ManagedByLabel: "someone-else"},
+	})
+	if err == nil {
+		t.Fatal("expected error when trying to change managed-by label, got nil")
+	}
+}


### PR DESCRIPTION
Add ns_update MCP tool that allows updating labels, annotations, and/or resource quota preset on tentacular-managed namespaces. Rejects changes to the managed-by label and requires at least one update field. Includes UpdateResourceQuota helper in pkg/k8s/quota.go, 7 unit tests, openspec updates, and README entry.