### PR TITLE
feat: add wf_restart tool for rollout-restarting deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Developer workstations holding cluster-wide admin kubeconfig is a security anti-
                             |  |   |  call handler              |  |
                             |  |   |  marshal result            |  |
                             |  |   v                            |  |
-                            |  | pkg/tools/*.go (31 tools)      |  |
+                            |  | pkg/tools/*.go (32 tools)      |  |
                             |  |   |                            |  |
                             |  |   v                            |  |
                             |  | pkg/k8s/* (K8s client layer)   |  |
@@ -109,7 +109,7 @@ curl http://localhost:8080/healthz
 
 ## MCP Tools
 
-31 tools organized across 12 functional groups. All namespace-scoped tools enforce a self-protection guard that rejects operations targeting `tentacular-system`.
+32 tools organized across 12 functional groups. All namespace-scoped tools enforce a self-protection guard that rejects operations targeting `tentacular-system`.
 
 ### Namespace Lifecycle
 
@@ -136,6 +136,7 @@ curl http://localhost:8080/healthz
 | `wf_logs` | Tail pod logs (snapshot, not streaming). Supports container selection and line count. |
 | `wf_events` | List namespace events with type, reason, message, object reference, and count. |
 | `wf_jobs` | List Jobs and CronJobs in a namespace with status, schedule, and duration. |
+| `wf_restart` | Rollout restart a deployment by patching the pod template with a restart timestamp. Useful after ConfigMap/Secret changes, credential rotation, or gVisor enablement. |
 
 ### Cluster Operations
 
@@ -333,7 +334,7 @@ Every created namespace gets:
 
 ### RBAC Scoping
 
-The server's ClusterRole is scoped to exactly the verbs and resources needed by the 31 tools. It is significantly narrower than `cluster-admin`. Key constraints:
+The server's ClusterRole is scoped to exactly the verbs and resources needed by the 32 tools. It is significantly narrower than `cluster-admin`. Key constraints:
 - Read-only access to nodes, storage classes, runtime classes, CRDs
 - Create/delete for pods (gVisor verification only)
 - Namespaced CRUD for resources managed by tool handlers

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -68,6 +68,7 @@ Every namespace-accepting tool correctly calls `guard.CheckNamespace()` before a
 | wf_logs | params.Namespace | YES |
 | wf_events | params.Namespace | YES |
 | wf_jobs | params.Namespace | YES |
+| wf_restart | params.Namespace | YES |
 | cluster_preflight | params.Namespace | YES |
 | cluster_profile | params.Namespace | YES (conditional on non-empty, correct per D10) |
 | gvisor_check | (none) | N/A - cluster-scoped |

--- a/openspec/specs/workflow-introspection/spec.md
+++ b/openspec/specs/workflow-introspection/spec.md
@@ -51,3 +51,22 @@ The system SHALL list all Jobs and CronJobs in a namespace. For Jobs, return nam
 - **WHEN** the `wf_jobs` tool is called and no Jobs or CronJobs exist
 - **THEN** the system returns empty lists for both Jobs and CronJobs
 
+### Requirement: Rollout restart a deployment
+The system SHALL perform a rollout restart of a Deployment in a managed namespace by patching the pod template with a `tentacular.io/restartedAt` annotation containing the current UTC timestamp. This is the same mechanism as `kubectl rollout restart`. The system SHALL verify the namespace is managed by tentacular and that the deployment exists before patching. The system SHALL reject the operation if the target namespace is `tentacular-system` or if the namespace is not managed by tentacular.
+
+#### Scenario: Successful rollout restart
+- **WHEN** the `wf_restart` tool is called with `namespace: "dev-alice"` and `deployment: "web-app"` and the namespace is managed
+- **THEN** the system patches the deployment's pod template with a `tentacular.io/restartedAt` annotation and returns `restarted: true`
+
+#### Scenario: Reject restart in unmanaged namespace
+- **WHEN** the `wf_restart` tool is called with a namespace that is not managed by tentacular
+- **THEN** the system returns an error indicating the namespace is not managed
+
+#### Scenario: Deployment not found
+- **WHEN** the `wf_restart` tool is called with a deployment name that does not exist in the namespace
+- **THEN** the system returns an error indicating the deployment was not found
+
+#### Scenario: Reject restart in protected namespace
+- **WHEN** the `wf_restart` tool is called with `namespace: "tentacular-system"`
+- **THEN** the system returns an error indicating operations on `tentacular-system` are not allowed
+

--- a/pkg/tools/workflow.go
+++ b/pkg/tools/workflow.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -12,6 +13,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/randybias/tentacular-mcp/pkg/guard"
 	"github.com/randybias/tentacular-mcp/pkg/k8s"
@@ -102,6 +104,19 @@ type WfJobsResult struct {
 	CronJobs []WfCronJobInfo `json:"cronjobs"`
 }
 
+// WfRestartParams are the parameters for wf_restart.
+type WfRestartParams struct {
+	Namespace  string `json:"namespace" jsonschema:"Namespace containing the deployment"`
+	Deployment string `json:"deployment" jsonschema:"Name of the deployment to restart"`
+}
+
+// WfRestartResult is the result of wf_restart.
+type WfRestartResult struct {
+	Namespace  string `json:"namespace"`
+	Deployment string `json:"deployment"`
+	Restarted  bool   `json:"restarted"`
+}
+
 func registerWorkflowTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_pods",
@@ -144,6 +159,17 @@ func registerWorkflowTools(srv *mcp.Server, client *k8s.Client) {
 			return nil, WfJobsResult{}, err
 		}
 		result, err := handleWfJobs(ctx, client, params)
+		return nil, result, err
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "wf_restart",
+		Description: "Rollout restart a deployment in a managed namespace by patching the pod template with a restart timestamp. Useful after ConfigMap/Secret changes, credential rotation, or gVisor enablement.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, params WfRestartParams) (*mcp.CallToolResult, WfRestartResult, error) {
+		if err := guard.CheckNamespace(params.Namespace); err != nil {
+			return nil, WfRestartResult{}, err
+		}
+		result, err := handleWfRestart(ctx, client, params)
 		return nil, result, err
 	})
 }
@@ -348,4 +374,48 @@ func jobStatus(job batchv1.Job) string {
 		return "Running"
 	}
 	return "Pending"
+}
+
+func handleWfRestart(ctx context.Context, client *k8s.Client, params WfRestartParams) (WfRestartResult, error) {
+	if err := k8s.CheckManagedNamespace(ctx, client, params.Namespace); err != nil {
+		return WfRestartResult{}, err
+	}
+
+	// Verify the deployment exists.
+	_, err := client.Clientset.AppsV1().Deployments(params.Namespace).Get(ctx, params.Deployment, metav1.GetOptions{})
+	if err != nil {
+		return WfRestartResult{}, fmt.Errorf("get deployment %q in namespace %q: %w", params.Deployment, params.Namespace, err)
+	}
+
+	// Rollout restart: patch the pod template annotation with a timestamp.
+	// This is the same mechanism as `kubectl rollout restart`.
+	restartAnnotation := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"tentacular.io/restartedAt": time.Now().UTC().Format(time.RFC3339),
+					},
+				},
+			},
+		},
+	}
+
+	patchBody, err := json.Marshal(restartAnnotation)
+	if err != nil {
+		return WfRestartResult{}, fmt.Errorf("marshal restart patch: %w", err)
+	}
+
+	_, err = client.Clientset.AppsV1().Deployments(params.Namespace).Patch(
+		ctx, params.Deployment, types.MergePatchType, patchBody, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return WfRestartResult{}, fmt.Errorf("patch deployment %q for rollout restart: %w", params.Deployment, err)
+	}
+
+	return WfRestartResult{
+		Namespace:  params.Namespace,
+		Deployment: params.Deployment,
+		Restarted:  true,
+	}, nil
 }

--- a/pkg/tools/workflow_test.go
+++ b/pkg/tools/workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -372,5 +373,132 @@ func TestWfJobsCronJobSuspended(t *testing.T) {
 	}
 	if !result.CronJobs[0].Suspended {
 		t.Error("expected Suspended=true for suspended cronjob")
+	}
+}
+
+func TestWfRestartSuccess(t *testing.T) {
+	client := newWfTestClient()
+	ctx := context.Background()
+
+	// Create a managed namespace
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "restart-ns",
+			Labels: map[string]string{
+				k8s.ManagedByLabel: k8s.ManagedByValue,
+			},
+		},
+	}
+	_, err := client.Clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("setup: create ns: %v", err)
+	}
+
+	// Create a deployment
+	replicas := int32(1)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-app",
+			Namespace: "restart-ns",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "web"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "web"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "web", Image: "nginx:1.25"},
+					},
+				},
+			},
+		},
+	}
+	_, err = client.Clientset.AppsV1().Deployments("restart-ns").Create(ctx, dep, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("setup: create deployment: %v", err)
+	}
+
+	result, err := handleWfRestart(ctx, client, WfRestartParams{
+		Namespace:  "restart-ns",
+		Deployment: "web-app",
+	})
+	if err != nil {
+		t.Fatalf("handleWfRestart: %v", err)
+	}
+	if !result.Restarted {
+		t.Error("expected Restarted=true")
+	}
+	if result.Namespace != "restart-ns" {
+		t.Errorf("namespace: got %q, want %q", result.Namespace, "restart-ns")
+	}
+	if result.Deployment != "web-app" {
+		t.Errorf("deployment: got %q, want %q", result.Deployment, "web-app")
+	}
+
+	// Verify the annotation was set on the pod template
+	updated, err := client.Clientset.AppsV1().Deployments("restart-ns").Get(ctx, "web-app", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated deployment: %v", err)
+	}
+	ann := updated.Spec.Template.Annotations
+	if ann == nil {
+		t.Fatal("expected annotations on pod template after restart")
+	}
+	if _, ok := ann["tentacular.io/restartedAt"]; !ok {
+		t.Error("expected tentacular.io/restartedAt annotation on pod template")
+	}
+}
+
+func TestWfRestartUnmanagedNamespace(t *testing.T) {
+	client := newWfTestClient()
+	ctx := context.Background()
+
+	// Create an unmanaged namespace
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "unmanaged-ns"},
+	}
+	_, err := client.Clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("setup: create ns: %v", err)
+	}
+
+	_, err = handleWfRestart(ctx, client, WfRestartParams{
+		Namespace:  "unmanaged-ns",
+		Deployment: "web-app",
+	})
+	if err == nil {
+		t.Fatal("expected error for unmanaged namespace, got nil")
+	}
+}
+
+func TestWfRestartDeploymentNotFound(t *testing.T) {
+	client := newWfTestClient()
+	ctx := context.Background()
+
+	// Create a managed namespace but no deployment
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "empty-restart-ns",
+			Labels: map[string]string{
+				k8s.ManagedByLabel: k8s.ManagedByValue,
+			},
+		},
+	}
+	_, err := client.Clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("setup: create ns: %v", err)
+	}
+
+	_, err = handleWfRestart(ctx, client, WfRestartParams{
+		Namespace:  "empty-restart-ns",
+		Deployment: "nonexistent",
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent deployment, got nil")
 	}
 }


### PR DESCRIPTION
Adds a new wf_restart tool that performs a rollout restart of a deployment in a managed namespace by patching the template with a tentacular.io/restartedAt annotation (same mechanism as kubectl rollout restart).

Use cases that justify this tool:
- ConfigMap/Secret changes: Kubernetes does not auto-restart pods when mounted ConfigMaps or Secrets change. wf_restart forces pods to pick up the new values.
- Stuck/degraded state recovery: when pods are in CrashLoopBackOff or degraded state, a rollout restart replaces them gracefully.
- Post-credential rotation: after cred_rotate invalidates all prior ServiceAccount tokens, running deployments need a restart to obtain fresh tokens.
- gVisor enablement: after gvisor_annotate_ns annotates a namespace, existing pods continue on the old runtime. A restart forces new pods onto the gVisor sandbox.