### PR TITLE
feat: enhance audit_rbac with escalation detection and remediation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ curl http://localhost:8080/healthz
 
 | Tool | Description |
 |------|-------------|
-| `audit_rbac` | Scan namespace RBAC for over-permissioned roles (wildcard verbs, escalation paths). |
+| `audit_rbac` | Scan namespace RBAC for over-permissioned roles (wildcard verbs, sensitive resources, escalation paths via bind/escalate/impersonate) with remediation suggestions. |
 | `audit_netpol` | Verify NetworkPolicy coverage: default-deny presence, policy analysis. |
 | `audit_psa` | Validate Pod Security Admission labels against the restricted profile. |
 

--- a/openspec/specs/security-audit/spec.md
+++ b/openspec/specs/security-audit/spec.md
@@ -4,11 +4,11 @@
 TBD - created by archiving change in-cluster-mcp-server. Update Purpose after archive.
 ## Requirements
 ### Requirement: Audit RBAC for over-permissions
-The system SHALL scan all Roles and RoleBindings in a given namespace and flag any rules that grant wildcard verbs (`*`), wildcard resources (`*`), or access to sensitive resources (secrets with `list`/`watch`, pods/exec, nodes). The system SHALL return a list of findings, each with the role name, the problematic rule, and a severity level (high/medium/low). The system SHALL reject the operation if the target namespace is `tentacular-system`.
+The system SHALL scan all Roles and RoleBindings in a given namespace and flag any rules that grant wildcard verbs (`*`), wildcard resources (`*`), access to sensitive resources (secrets, serviceaccounts/token, pods/exec, pods/attach), or escalation verbs (`bind`, `escalate`, `impersonate`). The system SHALL return a list of findings, each with the role name, the problematic rule, a severity level (high/medium/low), and a remediation suggestion. The system SHALL reject the operation if the target namespace is `tentacular-system`.
 
 #### Scenario: Namespace with over-permissioned role
 - **WHEN** the `audit_rbac` tool is called with `namespace: "dev-alice"` and a Role grants `*` verbs on secrets
-- **THEN** the system returns a finding with severity `high`, the role name, and the flagged rule
+- **THEN** the system returns a finding with severity `high`, the role name, the flagged rule, and a remediation suggestion
 
 #### Scenario: Namespace with clean RBAC
 - **WHEN** the `audit_rbac` tool is called and all Roles follow least-privilege principles
@@ -17,6 +17,18 @@ The system SHALL scan all Roles and RoleBindings in a given namespace and flag a
 #### Scenario: Also inspect ClusterRoleBindings targeting namespace
 - **WHEN** the `audit_rbac` tool is called and a ClusterRoleBinding grants a ClusterRole to a ServiceAccount in the target namespace
 - **THEN** the system includes any over-permissioned rules from the bound ClusterRole in the findings
+
+#### Scenario: Detect escalation via bind verb
+- **WHEN** the `audit_rbac` tool is called and a Role grants the `bind` verb on roles or clusterroles
+- **THEN** the system returns a finding with severity `high` indicating privilege escalation risk and a remediation to remove the verb
+
+#### Scenario: Detect escalation via escalate verb
+- **WHEN** the `audit_rbac` tool is called and a Role grants the `escalate` verb
+- **THEN** the system returns a finding with severity `high` indicating the role can modify its own permissions
+
+#### Scenario: Detect impersonation capability
+- **WHEN** the `audit_rbac` tool is called and a Role grants the `impersonate` verb on users, groups, or serviceaccounts
+- **THEN** the system returns a finding with severity `high` indicating identity impersonation risk
 
 ### Requirement: Audit network policy coverage
 The system SHALL verify that a namespace has at least a default-deny NetworkPolicy (denying all ingress and egress) and report on all NetworkPolicies present. The system SHALL flag namespaces that allow unrestricted egress or have no NetworkPolicies at all. The system SHALL reject the operation if the target namespace is `tentacular-system`.

--- a/pkg/tools/audit.go
+++ b/pkg/tools/audit.go
@@ -20,10 +20,11 @@ type AuditRbacParams struct {
 
 // AuditFinding is a single RBAC audit finding.
 type AuditFinding struct {
-	Role     string `json:"role"`
-	Rule     string `json:"rule"`
-	Severity string `json:"severity"`
-	Reason   string `json:"reason"`
+	Role        string `json:"role"`
+	Rule        string `json:"rule"`
+	Severity    string `json:"severity"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
 }
 
 // AuditRbacResult is the result of audit_rbac.
@@ -79,7 +80,7 @@ type AuditPsaResult struct {
 func registerAuditTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "audit_rbac",
-		Description: "Audit RBAC in a namespace: scan for wildcard verbs/resources, sensitive access, and ClusterRoleBindings targeting namespace service accounts.",
+		Description: "Audit RBAC in a namespace: scan for wildcard verbs/resources, sensitive access, escalation paths (bind/escalate/impersonate verbs), and ClusterRoleBindings targeting namespace service accounts. Returns findings with remediation suggestions.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params AuditRbacParams) (*mcp.CallToolResult, AuditRbacResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, AuditRbacResult{}, err
@@ -118,6 +119,13 @@ var sensitiveResources = map[string]bool{
 	"pods/attach":           true,
 }
 
+// escalationVerbs are verbs that enable privilege escalation in RBAC.
+var escalationVerbs = map[string]bool{
+	"bind":        true,
+	"escalate":    true,
+	"impersonate": true,
+}
+
 func handleAuditRbac(ctx context.Context, client *k8s.Client, params AuditRbacParams) (AuditRbacResult, error) {
 	findings := []AuditFinding{}
 
@@ -128,40 +136,8 @@ func handleAuditRbac(ctx context.Context, client *k8s.Client, params AuditRbacPa
 	}
 
 	for _, role := range roles.Items {
-		for _, rule := range role.Rules {
-			ruleDesc := ruleDescription(rule)
-			// Check wildcard verbs
-			for _, verb := range rule.Verbs {
-				if verb == "*" {
-					findings = append(findings, AuditFinding{
-						Role:     fmt.Sprintf("Role/%s", role.Name),
-						Rule:     ruleDesc,
-						Severity: "high",
-						Reason:   "wildcard verb grants all permissions",
-					})
-				}
-			}
-			// Check wildcard resources
-			for _, res := range rule.Resources {
-				if res == "*" {
-					findings = append(findings, AuditFinding{
-						Role:     fmt.Sprintf("Role/%s", role.Name),
-						Rule:     ruleDesc,
-						Severity: "high",
-						Reason:   "wildcard resource grants access to all resource types",
-					})
-				}
-				// Check sensitive resources
-				if sensitiveResources[res] {
-					findings = append(findings, AuditFinding{
-						Role:     fmt.Sprintf("Role/%s", role.Name),
-						Rule:     ruleDesc,
-						Severity: "medium",
-						Reason:   fmt.Sprintf("access to sensitive resource %q", res),
-					})
-				}
-			}
-		}
+		roleName := fmt.Sprintf("Role/%s", role.Name)
+		findings = auditRules(findings, roleName, role.Rules)
 	}
 
 	// Scan RoleBindings for ClusterRole bindings (which may escalate privileges)
@@ -172,10 +148,11 @@ func handleAuditRbac(ctx context.Context, client *k8s.Client, params AuditRbacPa
 	for _, rb := range rbs.Items {
 		if rb.RoleRef.Kind == "ClusterRole" {
 			findings = append(findings, AuditFinding{
-				Role:     fmt.Sprintf("RoleBinding/%s", rb.Name),
-				Rule:     fmt.Sprintf("binds ClusterRole/%s", rb.RoleRef.Name),
-				Severity: "low",
-				Reason:   "RoleBinding references a ClusterRole; review cluster-level permissions",
+				Role:        fmt.Sprintf("RoleBinding/%s", rb.Name),
+				Rule:        fmt.Sprintf("binds ClusterRole/%s", rb.RoleRef.Name),
+				Severity:    "low",
+				Reason:      "RoleBinding references a ClusterRole; review cluster-level permissions",
+				Remediation: "Replace with a namespaced Role if the required permissions are namespace-scoped.",
 			})
 		}
 	}
@@ -189,16 +166,73 @@ func handleAuditRbac(ctx context.Context, client *k8s.Client, params AuditRbacPa
 		for _, subj := range crb.Subjects {
 			if subj.Kind == "ServiceAccount" && subj.Namespace == params.Namespace {
 				findings = append(findings, AuditFinding{
-					Role:     fmt.Sprintf("ClusterRoleBinding/%s", crb.Name),
-					Rule:     fmt.Sprintf("binds ClusterRole/%s to SA %s/%s", crb.RoleRef.Name, params.Namespace, subj.Name),
-					Severity: "medium",
-					Reason:   "service account in namespace has cluster-wide permissions",
+					Role:        fmt.Sprintf("ClusterRoleBinding/%s", crb.Name),
+					Rule:        fmt.Sprintf("binds ClusterRole/%s to SA %s/%s", crb.RoleRef.Name, params.Namespace, subj.Name),
+					Severity:    "medium",
+					Reason:      "service account in namespace has cluster-wide permissions",
+					Remediation: "Replace with a namespaced RoleBinding unless cluster-wide access is required.",
 				})
 			}
 		}
 	}
 
 	return AuditRbacResult{Findings: findings}, nil
+}
+
+// auditRules checks a set of RBAC policy rules for security issues and appends findings.
+func auditRules(findings []AuditFinding, roleName string, rules []rbacv1.PolicyRule) []AuditFinding {
+	for _, rule := range rules {
+		ruleDesc := ruleDescription(rule)
+
+		// Check wildcard verbs
+		for _, verb := range rule.Verbs {
+			if verb == "*" {
+				findings = append(findings, AuditFinding{
+					Role:        roleName,
+					Rule:        ruleDesc,
+					Severity:    "high",
+					Reason:      "wildcard verb grants all permissions",
+					Remediation: "Replace '*' with explicit verbs (e.g. get, list, watch, create, update, delete).",
+				})
+			}
+		}
+
+		// Check escalation verbs (bind, escalate, impersonate)
+		for _, verb := range rule.Verbs {
+			if escalationVerbs[verb] {
+				findings = append(findings, AuditFinding{
+					Role:        roleName,
+					Rule:        ruleDesc,
+					Severity:    "high",
+					Reason:      fmt.Sprintf("%q verb enables privilege escalation", verb),
+					Remediation: fmt.Sprintf("Remove the %q verb unless this role explicitly needs to grant or assume other identities.", verb),
+				})
+			}
+		}
+
+		// Check wildcard resources and sensitive resources
+		for _, res := range rule.Resources {
+			if res == "*" {
+				findings = append(findings, AuditFinding{
+					Role:        roleName,
+					Rule:        ruleDesc,
+					Severity:    "high",
+					Reason:      "wildcard resource grants access to all resource types",
+					Remediation: "Replace '*' with the specific resources this role needs access to.",
+				})
+			}
+			if sensitiveResources[res] {
+				findings = append(findings, AuditFinding{
+					Role:        roleName,
+					Rule:        ruleDesc,
+					Severity:    "medium",
+					Reason:      fmt.Sprintf("access to sensitive resource %q", res),
+					Remediation: fmt.Sprintf("Restrict %q access to only the verbs required (e.g. get instead of list/watch).", res),
+				})
+			}
+		}
+	}
+	return findings
 }
 
 func ruleDescription(rule rbacv1.PolicyRule) string {

--- a/pkg/tools/audit_test.go
+++ b/pkg/tools/audit_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -172,6 +173,156 @@ func TestAuditRbacRoleBindingToClusterRole(t *testing.T) {
 	}
 	if !hasLow {
 		t.Error("expected low severity finding for RoleBinding referencing ClusterRole")
+	}
+}
+
+func TestAuditRbacEscalationBindVerb(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "escalator", Namespace: "esc-ns"},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"rbac.authorization.k8s.io"},
+				Resources: []string{"roles"},
+				Verbs:     []string{"bind"},
+			},
+		},
+	}
+	client.Clientset.RbacV1().Roles("esc-ns").Create(ctx, role, metav1.CreateOptions{})
+
+	result, err := handleAuditRbac(ctx, client, AuditRbacParams{Namespace: "esc-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditRbac: %v", err)
+	}
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Severity == "high" && strings.Contains(f.Reason, "bind") {
+			found = true
+			if f.Remediation == "" {
+				t.Error("expected remediation text for bind verb finding")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected high severity finding for bind verb")
+	}
+}
+
+func TestAuditRbacEscalationEscalateVerb(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "self-escalator", Namespace: "esc2-ns"},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"rbac.authorization.k8s.io"},
+				Resources: []string{"clusterroles"},
+				Verbs:     []string{"escalate"},
+			},
+		},
+	}
+	client.Clientset.RbacV1().Roles("esc2-ns").Create(ctx, role, metav1.CreateOptions{})
+
+	result, err := handleAuditRbac(ctx, client, AuditRbacParams{Namespace: "esc2-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditRbac: %v", err)
+	}
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Severity == "high" && strings.Contains(f.Reason, "escalate") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected high severity finding for escalate verb")
+	}
+}
+
+func TestAuditRbacEscalationImpersonateVerb(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "impersonator", Namespace: "imp-ns"},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"users"},
+				Verbs:     []string{"impersonate"},
+			},
+		},
+	}
+	client.Clientset.RbacV1().Roles("imp-ns").Create(ctx, role, metav1.CreateOptions{})
+
+	result, err := handleAuditRbac(ctx, client, AuditRbacParams{Namespace: "imp-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditRbac: %v", err)
+	}
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Severity == "high" && strings.Contains(f.Reason, "impersonate") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected high severity finding for impersonate verb")
+	}
+}
+
+func TestAuditRbacRemediationOnWildcard(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "wildcard-role", Namespace: "rem-ns"},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"*"},
+			},
+		},
+	}
+	client.Clientset.RbacV1().Roles("rem-ns").Create(ctx, role, metav1.CreateOptions{})
+
+	result, err := handleAuditRbac(ctx, client, AuditRbacParams{Namespace: "rem-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditRbac: %v", err)
+	}
+
+	for _, f := range result.Findings {
+		if f.Remediation == "" {
+			t.Errorf("finding %q missing remediation text", f.Reason)
+		}
+	}
+}
+
+func TestAuditRbacRemediationOnClusterRoleBinding(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "crb-rem"},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "edit"},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "mysa", Namespace: "rem2-ns"}},
+	}
+	client.Clientset.RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{})
+
+	result, err := handleAuditRbac(ctx, client, AuditRbacParams{Namespace: "rem2-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditRbac: %v", err)
+	}
+
+	for _, f := range result.Findings {
+		if f.Remediation == "" {
+			t.Errorf("finding %q missing remediation text", f.Reason)
+		}
 	}
 }
 


### PR DESCRIPTION
Add detection for privilege escalation verbs (bind, escalate, impersonate) as high-severity findings. Add remediation suggestions to all finding types so callers get actionable guidance.

Extract rule scanning into auditRules helper for clarity.