### PR TITLE
feat: enhance audit_netpol with broad-allow and cross-namespace detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ curl http://localhost:8080/healthz
 | Tool | Description |
 |------|-------------|
 | `audit_rbac` | Scan namespace RBAC for over-permissioned roles (wildcard verbs, sensitive resources, escalation paths via bind/escalate/impersonate) with remediation suggestions. |
-| `audit_netpol` | Verify NetworkPolicy coverage: default-deny presence, policy analysis. |
+| `audit_netpol` | Verify NetworkPolicy coverage: default-deny presence, overly broad allow rules, cross-namespace ingress detection, with remediation suggestions. |
 | `audit_psa` | Validate Pod Security Admission labels: enforce/audit/warn levels, privileged detection, level mismatch detection, with remediation suggestions. |
 
 ## Authentication

--- a/openspec/specs/security-audit/spec.md
+++ b/openspec/specs/security-audit/spec.md
@@ -31,7 +31,7 @@ The system SHALL scan all Roles and RoleBindings in a given namespace and flag a
 - **THEN** the system returns a finding with severity `high` indicating identity impersonation risk
 
 ### Requirement: Audit network policy coverage
-The system SHALL verify that a namespace has at least a default-deny NetworkPolicy (denying all ingress and egress) and report on all NetworkPolicies present. The system SHALL flag namespaces that allow unrestricted egress or have no NetworkPolicies at all. The system SHALL reject the operation if the target namespace is `tentacular-system`.
+The system SHALL verify that a namespace has at least a default-deny NetworkPolicy (denying all ingress and egress) and report on all NetworkPolicies present. The system SHALL flag namespaces that allow unrestricted egress, have no NetworkPolicies at all, contain overly broad allow rules that negate default-deny, or allow cross-namespace ingress via empty `namespaceSelector`. The system SHALL return findings with remediation suggestions. The system SHALL reject the operation if the target namespace is `tentacular-system`.
 
 #### Scenario: Namespace with default-deny policy
 - **WHEN** the `audit_netpol` tool is called with `namespace: "dev-alice"` and a default-deny policy exists
@@ -39,11 +39,23 @@ The system SHALL verify that a namespace has at least a default-deny NetworkPoli
 
 #### Scenario: Namespace without network policies
 - **WHEN** the `audit_netpol` tool is called and no NetworkPolicies exist in the namespace
-- **THEN** the system returns `default_deny: false` with a finding flagging the namespace as having unrestricted network access
+- **THEN** the system returns `default_deny: false` with a finding flagging the namespace as having unrestricted network access and a remediation suggestion
 
 #### Scenario: Namespace with partial coverage
 - **WHEN** the `audit_netpol` tool is called and the namespace has ingress policies but no egress restriction
 - **THEN** the system returns `default_deny: false` with a finding noting unrestricted egress
+
+#### Scenario: Overly broad ingress allow rule
+- **WHEN** the `audit_netpol` tool is called and a NetworkPolicy has an ingress rule with an empty peer (`from: [{}]`) that allows traffic from all sources
+- **THEN** the system returns a finding with severity `high` indicating the rule negates default-deny
+
+#### Scenario: Overly broad egress allow rule
+- **WHEN** the `audit_netpol` tool is called and a NetworkPolicy has an egress rule with an empty peer (`to: [{}]`) that allows traffic to all destinations
+- **THEN** the system returns a finding with severity `high` indicating the rule negates default-deny
+
+#### Scenario: Cross-namespace ingress via empty namespaceSelector
+- **WHEN** the `audit_netpol` tool is called and a NetworkPolicy allows ingress from all namespaces via an empty `namespaceSelector`
+- **THEN** the system returns a finding with severity `medium` recommending restricting the selector
 
 ### Requirement: Audit Pod Security Admission labels
 The system SHALL check the Pod Security Admission labels on a namespace and report the enforce, audit, and warn levels. The system SHALL flag namespaces that do not have PSA enforce set to `restricted` or that have no PSA labels at all. The system SHALL treat `privileged` enforce level as high severity (all checks disabled) and `baseline` as medium severity. The system SHALL detect when audit or warn levels are weaker than the enforce level. The system SHALL return findings with remediation suggestions. The system SHALL reject the operation if the target namespace is `tentacular-system`.

--- a/pkg/tools/audit.go
+++ b/pkg/tools/audit.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -46,8 +47,9 @@ type NetpolInfo struct {
 
 // AuditNetpolFinding is a single netpol audit finding.
 type AuditNetpolFinding struct {
-	Severity string `json:"severity"`
-	Message  string `json:"message"`
+	Severity    string `json:"severity"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
 }
 
 // AuditNetpolResult is the result of audit_netpol.
@@ -92,7 +94,7 @@ func registerAuditTools(srv *mcp.Server, client *k8s.Client) {
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "audit_netpol",
-		Description: "Audit network policies in a namespace: check for default-deny policy, missing egress restrictions, and list all policies.",
+		Description: "Audit network policies in a namespace: check for default-deny policy, missing egress restrictions, overly broad allow rules, cross-namespace ingress via empty namespaceSelector, and list all policies. Returns findings with remediation suggestions.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params AuditNetpolParams) (*mcp.CallToolResult, AuditNetpolResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, AuditNetpolResult{}, err
@@ -288,6 +290,41 @@ func handleAuditNetpol(ctx context.Context, client *k8s.Client, params AuditNetp
 			}
 		}
 
+		// Check for overly broad ingress allow rules
+		for _, ingress := range p.Spec.Ingress {
+			for _, from := range ingress.From {
+				if isAllowAll(from.PodSelector, from.NamespaceSelector, from.IPBlock) {
+					findings = append(findings, AuditNetpolFinding{
+						Severity:    "high",
+						Message:     fmt.Sprintf("NetworkPolicy %q has an ingress rule that allows traffic from all sources, negating default-deny", p.Name),
+						Remediation: "Restrict the ingress rule to specific pod/namespace selectors or CIDR ranges.",
+					})
+				} else if from.NamespaceSelector != nil &&
+					len(from.NamespaceSelector.MatchLabels) == 0 &&
+					len(from.NamespaceSelector.MatchExpressions) == 0 &&
+					from.PodSelector == nil {
+					findings = append(findings, AuditNetpolFinding{
+						Severity:    "medium",
+						Message:     fmt.Sprintf("NetworkPolicy %q allows ingress from all namespaces via empty namespaceSelector", p.Name),
+						Remediation: "Add matchLabels to the namespaceSelector to restrict which namespaces can send traffic.",
+					})
+				}
+			}
+		}
+
+		// Check for overly broad egress allow rules
+		for _, egress := range p.Spec.Egress {
+			for _, to := range egress.To {
+				if isAllowAll(to.PodSelector, to.NamespaceSelector, to.IPBlock) {
+					findings = append(findings, AuditNetpolFinding{
+						Severity:    "high",
+						Message:     fmt.Sprintf("NetworkPolicy %q has an egress rule that allows traffic to all destinations, negating default-deny", p.Name),
+						Remediation: "Restrict the egress rule to specific pod/namespace selectors or CIDR ranges.",
+					})
+				}
+			}
+		}
+
 		selectorStr := "all pods"
 		if len(p.Spec.PodSelector.MatchLabels) > 0 {
 			parts := []string{}
@@ -306,15 +343,17 @@ func handleAuditNetpol(ctx context.Context, client *k8s.Client, params AuditNetp
 
 	if !defaultDeny {
 		findings = append(findings, AuditNetpolFinding{
-			Severity: "high",
-			Message:  "no default-deny NetworkPolicy found; traffic is unrestricted by default",
+			Severity:    "high",
+			Message:     "no default-deny NetworkPolicy found; traffic is unrestricted by default",
+			Remediation: "Create a NetworkPolicy with empty podSelector and both Ingress+Egress policyTypes with no allow rules.",
 		})
 	}
 
 	if !hasEgressRestriction {
 		findings = append(findings, AuditNetpolFinding{
-			Severity: "medium",
-			Message:  "no egress NetworkPolicy found; pods may be able to reach external services",
+			Severity:    "medium",
+			Message:     "no egress NetworkPolicy found; pods may be able to reach external services",
+			Remediation: "Add a NetworkPolicy with policyType Egress to control outbound traffic.",
 		})
 	}
 
@@ -323,6 +362,13 @@ func handleAuditNetpol(ctx context.Context, client *k8s.Client, params AuditNetp
 		Policies:    policyInfos,
 		Findings:    findings,
 	}, nil
+}
+
+// isAllowAll returns true when a NetworkPolicy peer matches all traffic.
+// This happens when all selector/IPBlock fields are nil (the peer is `{}`),
+// which Kubernetes interprets as "allow from/to everywhere".
+func isAllowAll(podSel, nsSel *metav1.LabelSelector, ipBlock *networkingv1.IPBlock) bool {
+	return podSel == nil && nsSel == nil && ipBlock == nil
 }
 
 // psaLevelOrder maps PSA levels to a numeric rank for comparison.

--- a/pkg/tools/audit_test.go
+++ b/pkg/tools/audit_test.go
@@ -427,6 +427,136 @@ func TestAuditNetpolPoliciesListed(t *testing.T) {
 	}
 }
 
+func TestAuditNetpolBroadIngressAllowAll(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	// Policy with an ingress rule that has an empty peer (from: [{}]) — allows all traffic
+	policy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "allow-all-ingress", Namespace: "broad-ns"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{{}},
+				},
+			},
+		},
+	}
+	client.Clientset.NetworkingV1().NetworkPolicies("broad-ns").Create(ctx, policy, metav1.CreateOptions{})
+
+	result, err := handleAuditNetpol(ctx, client, AuditNetpolParams{Namespace: "broad-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditNetpol: %v", err)
+	}
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Severity == "high" && strings.Contains(f.Message, "allows traffic from all sources") {
+			found = true
+			if f.Remediation == "" {
+				t.Error("expected remediation text for broad ingress finding")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected high severity finding for allow-all ingress rule")
+	}
+}
+
+func TestAuditNetpolBroadEgressAllowAll(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	policy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "allow-all-egress", Namespace: "broad-eg-ns"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					To: []networkingv1.NetworkPolicyPeer{{}},
+				},
+			},
+		},
+	}
+	client.Clientset.NetworkingV1().NetworkPolicies("broad-eg-ns").Create(ctx, policy, metav1.CreateOptions{})
+
+	result, err := handleAuditNetpol(ctx, client, AuditNetpolParams{Namespace: "broad-eg-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditNetpol: %v", err)
+	}
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Severity == "high" && strings.Contains(f.Message, "allows traffic to all destinations") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected high severity finding for allow-all egress rule")
+	}
+}
+
+func TestAuditNetpolCrossNamespaceIngress(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	// Policy with empty namespaceSelector (matches all namespaces)
+	policy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "cross-ns", Namespace: "crossns-ns"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{},
+						},
+					},
+				},
+			},
+		},
+	}
+	client.Clientset.NetworkingV1().NetworkPolicies("crossns-ns").Create(ctx, policy, metav1.CreateOptions{})
+
+	result, err := handleAuditNetpol(ctx, client, AuditNetpolParams{Namespace: "crossns-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditNetpol: %v", err)
+	}
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Severity == "medium" && strings.Contains(f.Message, "all namespaces") {
+			found = true
+			if f.Remediation == "" {
+				t.Error("expected remediation text for cross-namespace finding")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected medium severity finding for empty namespaceSelector")
+	}
+}
+
+func TestAuditNetpolRemediationOnMissingDefaultDeny(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	result, err := handleAuditNetpol(ctx, client, AuditNetpolParams{Namespace: "no-policy-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditNetpol: %v", err)
+	}
+
+	for _, f := range result.Findings {
+		if f.Remediation == "" {
+			t.Errorf("finding %q missing remediation text", f.Message)
+		}
+	}
+}
+
 func TestAuditPsaCompliant(t *testing.T) {
 	client := newAuditTestClient()
 	ctx := context.Background()


### PR DESCRIPTION
Improvements to audit_netpol:

- Overly broad allow rules: a namespace can have a default-deny policy AND an allow-all policy (from: [{}] or to: [{}]) that completely negates it. The tool now detects empty NetworkPolicy peers in both ingress and egress rules and flags them as high severity.

- Cross-namespace ingress via empty namespaceSelector: a policy with namespaceSelector: {} allows ingress from every namespace in the cluster. This is a common footgun where developers intend to allow traffic from a specific namespace but accidentally match all. The tool now flags this as medium severity.

- Remediation suggestions: all finding types now include actionable remediation text so callers get guidance, not just a flag.