### PR TITLE
feat: enhance audit_psa with privileged detection and level mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ curl http://localhost:8080/healthz
 |------|-------------|
 | `audit_rbac` | Scan namespace RBAC for over-permissioned roles (wildcard verbs, escalation paths). |
 | `audit_netpol` | Verify NetworkPolicy coverage: default-deny presence, policy analysis. |
-| `audit_psa` | Validate Pod Security Admission labels against the restricted profile. |
+| `audit_psa` | Validate Pod Security Admission labels: enforce/audit/warn levels, privileged detection, level mismatch detection, with remediation suggestions. |
 
 ## Authentication
 

--- a/openspec/specs/security-audit/spec.md
+++ b/openspec/specs/security-audit/spec.md
@@ -34,17 +34,29 @@ The system SHALL verify that a namespace has at least a default-deny NetworkPoli
 - **THEN** the system returns `default_deny: false` with a finding noting unrestricted egress
 
 ### Requirement: Audit Pod Security Admission labels
-The system SHALL check the Pod Security Admission labels on a namespace and report the enforce, audit, and warn levels. The system SHALL flag namespaces that do not have PSA enforce set to `restricted` or that have no PSA labels at all. The system SHALL reject the operation if the target namespace is `tentacular-system`.
+The system SHALL check the Pod Security Admission labels on a namespace and report the enforce, audit, and warn levels. The system SHALL flag namespaces that do not have PSA enforce set to `restricted` or that have no PSA labels at all. The system SHALL treat `privileged` enforce level as high severity (all checks disabled) and `baseline` as medium severity. The system SHALL detect when audit or warn levels are weaker than the enforce level. The system SHALL return findings with remediation suggestions. The system SHALL reject the operation if the target namespace is `tentacular-system`.
 
 #### Scenario: Namespace with restricted PSA
-- **WHEN** the `audit_psa` tool is called with `namespace: "dev-alice"` and PSA enforce is `restricted`
-- **THEN** the system returns `compliant: true` with the enforce, audit, and warn levels
+- **WHEN** the `audit_psa` tool is called with `namespace: "dev-alice"` and PSA enforce is `restricted` with matching audit and warn levels
+- **THEN** the system returns `compliant: true` with the enforce, audit, and warn levels and no findings
 
-#### Scenario: Namespace with baseline or privileged PSA
+#### Scenario: Namespace with privileged PSA
+- **WHEN** the `audit_psa` tool is called and PSA enforce is `privileged`
+- **THEN** the system returns `compliant: false` with a high-severity finding indicating all pod security checks are disabled
+
+#### Scenario: Namespace with baseline PSA
 - **WHEN** the `audit_psa` tool is called and PSA enforce is `baseline`
-- **THEN** the system returns `compliant: false` with a finding recommending upgrade to `restricted`
+- **THEN** the system returns `compliant: false` with a medium-severity finding recommending upgrade to `restricted`
 
 #### Scenario: Namespace with no PSA labels
 - **WHEN** the `audit_psa` tool is called and no PSA labels exist on the namespace
-- **THEN** the system returns `compliant: false` with a finding noting the absence of PSA configuration
+- **THEN** the system returns `compliant: false` with a high-severity finding noting the absence of PSA configuration
+
+#### Scenario: Audit level weaker than enforce
+- **WHEN** the `audit_psa` tool is called and the audit level is weaker than the enforce level (e.g. enforce=restricted, audit=baseline)
+- **THEN** the system returns a medium-severity finding noting the audit log will not capture all violations
+
+#### Scenario: Warn level weaker than enforce
+- **WHEN** the `audit_psa` tool is called and the warn level is weaker than the enforce level
+- **THEN** the system returns a medium-severity finding noting users will not see warnings for all enforced restrictions
 

--- a/pkg/tools/audit.go
+++ b/pkg/tools/audit.go
@@ -63,8 +63,9 @@ type AuditPsaParams struct {
 
 // AuditPsaFinding is a single PSA audit finding.
 type AuditPsaFinding struct {
-	Severity string `json:"severity"`
-	Message  string `json:"message"`
+	Severity    string `json:"severity"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
 }
 
 // AuditPsaResult is the result of audit_psa.
@@ -101,7 +102,7 @@ func registerAuditTools(srv *mcp.Server, client *k8s.Client) {
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "audit_psa",
-		Description: "Audit Pod Security Admission labels on a namespace: check enforce/audit/warn levels and flag non-restricted or missing configuration.",
+		Description: "Audit Pod Security Admission labels on a namespace: check enforce/audit/warn levels, flag privileged or missing enforcement, detect audit/warn level mismatches, and return remediation suggestions.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params AuditPsaParams) (*mcp.CallToolResult, AuditPsaResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, AuditPsaResult{}, err
@@ -290,6 +291,14 @@ func handleAuditNetpol(ctx context.Context, client *k8s.Client, params AuditNetp
 	}, nil
 }
 
+// psaLevelOrder maps PSA levels to a numeric rank for comparison.
+// Higher rank = more restrictive.
+var psaLevelOrder = map[string]int{
+	"privileged": 0,
+	"baseline":   1,
+	"restricted": 2,
+}
+
 func handleAuditPsa(ctx context.Context, client *k8s.Client, params AuditPsaParams) (AuditPsaResult, error) {
 	ns, err := k8s.GetNamespace(ctx, client, params.Namespace)
 	if err != nil {
@@ -306,30 +315,61 @@ func handleAuditPsa(ctx context.Context, client *k8s.Client, params AuditPsaPara
 
 	if enforce == "" {
 		findings = append(findings, AuditPsaFinding{
-			Severity: "high",
-			Message:  "pod-security.kubernetes.io/enforce label is missing; no PSA enforcement active",
+			Severity:    "high",
+			Message:     "pod-security.kubernetes.io/enforce label is missing; no PSA enforcement active",
+			Remediation: "Add the label pod-security.kubernetes.io/enforce=restricted to the namespace.",
+		})
+		compliant = false
+	} else if enforce == "privileged" {
+		findings = append(findings, AuditPsaFinding{
+			Severity:    "high",
+			Message:     "PSA enforce level is \"privileged\"; all pod security checks are disabled",
+			Remediation: "Set pod-security.kubernetes.io/enforce to \"restricted\" (or \"baseline\" as a first step).",
 		})
 		compliant = false
 	} else if enforce != "restricted" {
 		findings = append(findings, AuditPsaFinding{
-			Severity: "medium",
-			Message:  fmt.Sprintf("PSA enforce level is %q; recommended level is \"restricted\"", enforce),
+			Severity:    "medium",
+			Message:     fmt.Sprintf("PSA enforce level is %q; recommended level is \"restricted\"", enforce),
+			Remediation: "Set pod-security.kubernetes.io/enforce to \"restricted\" for full pod security enforcement.",
 		})
 		compliant = false
 	}
 
 	if audit == "" {
 		findings = append(findings, AuditPsaFinding{
-			Severity: "low",
-			Message:  "pod-security.kubernetes.io/audit label is missing",
+			Severity:    "low",
+			Message:     "pod-security.kubernetes.io/audit label is missing",
+			Remediation: "Add pod-security.kubernetes.io/audit=restricted to log PSA violations in the audit log.",
 		})
 	}
 
 	if warn == "" {
 		findings = append(findings, AuditPsaFinding{
-			Severity: "low",
-			Message:  "pod-security.kubernetes.io/warn label is missing",
+			Severity:    "low",
+			Message:     "pod-security.kubernetes.io/warn label is missing",
+			Remediation: "Add pod-security.kubernetes.io/warn=restricted so users see warnings when deploying non-compliant pods.",
 		})
+	}
+
+	// Check audit/warn level mismatch: if they are weaker than enforce,
+	// users won't get dry-run feedback for the enforced policy.
+	if enforce != "" {
+		enforceRank := psaLevelOrder[enforce]
+		if audit != "" && psaLevelOrder[audit] < enforceRank {
+			findings = append(findings, AuditPsaFinding{
+				Severity:    "medium",
+				Message:     fmt.Sprintf("audit level %q is weaker than enforce level %q; audit log will not capture all violations", audit, enforce),
+				Remediation: fmt.Sprintf("Set pod-security.kubernetes.io/audit to %q or stricter to match enforcement.", enforce),
+			})
+		}
+		if warn != "" && psaLevelOrder[warn] < enforceRank {
+			findings = append(findings, AuditPsaFinding{
+				Severity:    "medium",
+				Message:     fmt.Sprintf("warn level %q is weaker than enforce level %q; users will not see warnings for all enforced restrictions", warn, enforce),
+				Remediation: fmt.Sprintf("Set pod-security.kubernetes.io/warn to %q or stricter to match enforcement.", enforce),
+			})
+		}
 	}
 
 	return AuditPsaResult{

--- a/pkg/tools/audit_test.go
+++ b/pkg/tools/audit_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -363,6 +364,153 @@ func TestAuditPsaNonRestrictedLevel(t *testing.T) {
 	}
 	if !hasMedium {
 		t.Error("expected medium finding for non-restricted PSA level")
+	}
+}
+
+func TestAuditPsaPrivilegedIsHighSeverity(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "priv-ns",
+			Labels: map[string]string{"pod-security.kubernetes.io/enforce": "privileged"},
+		},
+	}
+	client.Clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+
+	result, err := handleAuditPsa(ctx, client, AuditPsaParams{Namespace: "priv-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditPsa: %v", err)
+	}
+	if result.Compliant {
+		t.Error("expected Compliant=false for privileged enforce level")
+	}
+
+	hasHigh := false
+	for _, f := range result.Findings {
+		if f.Severity == "high" && strings.Contains(f.Message, "privileged") {
+			hasHigh = true
+		}
+	}
+	if !hasHigh {
+		t.Error("expected high severity finding for privileged enforce level")
+	}
+}
+
+func TestAuditPsaAuditLevelMismatch(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mismatch-audit-ns",
+			Labels: map[string]string{
+				"pod-security.kubernetes.io/enforce": "restricted",
+				"pod-security.kubernetes.io/audit":   "baseline",
+				"pod-security.kubernetes.io/warn":    "restricted",
+			},
+		},
+	}
+	client.Clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+
+	result, err := handleAuditPsa(ctx, client, AuditPsaParams{Namespace: "mismatch-audit-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditPsa: %v", err)
+	}
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Severity == "medium" && strings.Contains(f.Message, "audit level") {
+			found = true
+			if f.Remediation == "" {
+				t.Error("expected remediation text for audit mismatch finding")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected medium finding for audit level weaker than enforce")
+	}
+}
+
+func TestAuditPsaWarnLevelMismatch(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mismatch-warn-ns",
+			Labels: map[string]string{
+				"pod-security.kubernetes.io/enforce": "restricted",
+				"pod-security.kubernetes.io/audit":   "restricted",
+				"pod-security.kubernetes.io/warn":    "privileged",
+			},
+		},
+	}
+	client.Clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+
+	result, err := handleAuditPsa(ctx, client, AuditPsaParams{Namespace: "mismatch-warn-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditPsa: %v", err)
+	}
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Severity == "medium" && strings.Contains(f.Message, "warn level") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected medium finding for warn level weaker than enforce")
+	}
+}
+
+func TestAuditPsaNoMismatchWhenAllRestricted(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "all-restricted-ns",
+			Labels: map[string]string{
+				"pod-security.kubernetes.io/enforce": "restricted",
+				"pod-security.kubernetes.io/audit":   "restricted",
+				"pod-security.kubernetes.io/warn":    "restricted",
+			},
+		},
+	}
+	client.Clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+
+	result, err := handleAuditPsa(ctx, client, AuditPsaParams{Namespace: "all-restricted-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditPsa: %v", err)
+	}
+	if !result.Compliant {
+		t.Errorf("expected Compliant=true, findings: %v", result.Findings)
+	}
+	if len(result.Findings) != 0 {
+		t.Errorf("expected no findings for fully compliant namespace, got %d: %v", len(result.Findings), result.Findings)
+	}
+}
+
+func TestAuditPsaRemediationPresent(t *testing.T) {
+	client := newAuditTestClient()
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "rem-psa-ns"},
+	}
+	client.Clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+
+	result, err := handleAuditPsa(ctx, client, AuditPsaParams{Namespace: "rem-psa-ns"})
+	if err != nil {
+		t.Fatalf("handleAuditPsa: %v", err)
+	}
+
+	for _, f := range result.Findings {
+		if f.Remediation == "" {
+			t.Errorf("finding %q missing remediation text", f.Message)
+		}
 	}
 }
 


### PR DESCRIPTION
Improvements to audit_psa:

- Distinguish privileged from baseline severity: privileged enforce level disables all pod security checks entirely and is now flagged as high severity. Baseline (which does enforce some restrictions) stays medium.

- Audit/warn level mismatch detection: if enforce is restricted but audit or warn is set to a weaker level like baseline, developers won't get dry-run feedback when deploying workloads that only comply with the weaker level. This is a common misconfiguration when someone sets enforce manually but forgets the other labels.

- Remediation suggestions: all finding types now include actionable remediation text consistent with audit_rbac and audit_netpol.