### PR TITLE
fix: redact auth token from helm NOTES.txt and add chart icon

### DIFF
--- a/charts/tentacular-mcp/Chart.yaml
+++ b/charts/tentacular-mcp/Chart.yaml
@@ -4,6 +4,7 @@ description: An in-cluster MCP server for Kubernetes namespace lifecycle, creden
 type: application
 version: 0.1.0
 appVersion: "0.2.0"
+icon: https://raw.githubusercontent.com/randybias/tentacular/main/assets/logo.png
 home: https://github.com/randybias/tentacular-mcp
 sources:
   - https://github.com/randybias/tentacular-mcp

--- a/charts/tentacular-mcp/templates/NOTES.txt
+++ b/charts/tentacular-mcp/templates/NOTES.txt
@@ -7,22 +7,11 @@ tentacular-mcp has been deployed to namespace {{ .Release.Namespace }}.
 2. Verify health:
 
    curl http://localhost:8080/healthz
-{{- if and (not .Values.auth.existingSecret) .Values.auth.token }}
-
-3. Your auth token:
-
-   {{ .Values.auth.token }}
-
-   Use it with:
-
-   curl -H "Authorization: Bearer {{ .Values.auth.token }}" http://localhost:8080/mcp
-{{- else }}
 
 3. Retrieve the auth token:
 
    kubectl get secret {{ include "tentacular-mcp.authSecretName" . }} -n {{ .Release.Namespace }} \
      -o jsonpath='{.data.token}' | base64 -d
-{{- end }}
 
 4. Connect an MCP client:
 


### PR DESCRIPTION
NOTES.txt was printing the auth token in plain text in helm install output. Now it always shows the kubectl retrieval command instead, regardless of how the token was configured.

Also adds the tentacular logo as the Chart.yaml icon.