### PR TITLE
feat: add MCP ToolAnnotations to all 36 tools

### DIFF
--- a/openspec/changes/mcp-tool-annotations/.openspec.yaml
+++ b/openspec/changes/mcp-tool-annotations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-18

--- a/openspec/changes/mcp-tool-annotations/design.md
+++ b/openspec/changes/mcp-tool-annotations/design.md
@@ -1,0 +1,141 @@
+## Context
+
+The tentacular-mcp server registers 36 tools via `mcp.AddTool()` across 13 source files in `pkg/tools/`. Currently, all tool registrations use only `Name` and `Description` fields on the `mcp.Tool` struct. The MCP Go SDK v1.3.1 (already in go.mod) supports `ToolAnnotations` on the `Tool` struct, providing `ReadOnlyHint`, `DestructiveHint`, `IdempotentHint`, `OpenWorldHint`, and `Title` fields.
+
+Without annotations, agents must rely on description text parsing or hardcoded classification tables (e.g., in tentacular-skill) to determine whether a tool is safe to call without confirmation. This is fragile and requires cross-repo synchronization.
+
+The `ToolAnnotations` struct uses Go zero-value semantics deliberately: `ReadOnlyHint` and `IdempotentHint` are plain `bool` (default false), while `DestructiveHint` and `OpenWorldHint` are `*bool` (default nil, meaning "true" per spec). This distinction matters for correct annotation.
+
+### Current tool inventory (36 tools)
+
+| File | Tools |
+|------|-------|
+| `workflow.go` | wf_list, wf_describe, wf_status, wf_pods, wf_logs |
+| `discover.go` | wf_events, wf_jobs |
+| `run.go` | wf_run |
+| `deploy.go` | wf_apply, wf_remove, wf_restart |
+| `wf_health.go` | wf_health, wf_health_ns |
+| `namespace.go` | ns_create, ns_delete, ns_get, ns_list, ns_update |
+| `credential.go` | cred_issue_token, cred_kubeconfig, cred_rotate |
+| `health.go` | health_nodes, health_ns_usage, health_cluster_summary |
+| `audit.go` | audit_rbac, audit_netpol, audit_psa |
+| `gvisor.go` | gvisor_check, gvisor_annotate_ns, gvisor_verify |
+| `clusterops.go` | cluster_profile, cluster_preflight |
+| `proxy.go` | proxy_status |
+| `exoskeleton.go` | exo_status, exo_registration, exo_list |
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `ToolAnnotations` to every tool registration so agents can introspect safety classification via `tools/list`
+- Set `Title` on each tool for human-readable display
+- Set `ReadOnlyHint`, `DestructiveHint`, `IdempotentHint`, and `OpenWorldHint` appropriately per tool
+- Enrich `Description` strings with behavioral guidance (prerequisites, expected effects, safety notes)
+- Add test coverage verifying that every registered tool has annotations and that classifications are correct
+- Cover all 36 tools (the proposal listed 35; `exo_list` was missed and must be included)
+
+**Non-Goals:**
+- Changing tool behavior or handler logic
+- Adding new tools or removing existing tools
+- Modifying the MCP Go SDK or upgrading its version
+- Implementing client-side annotation consumption logic
+- Adding per-call confirmation prompts (that is a client/agent responsibility)
+
+## Decisions
+
+### D1: Annotation values by tier
+
+Three tiers with consistent annotation patterns:
+
+| Tier | ReadOnlyHint | DestructiveHint | IdempotentHint | OpenWorldHint |
+|------|-------------|-----------------|----------------|---------------|
+| Read-only | `true` | (ignored when ReadOnly) | (ignored when ReadOnly) | `ptr(false)` |
+| Write (non-destructive) | `false` | `ptr(false)` | per-tool | `ptr(false)` |
+| Destructive | `false` | `ptr(true)` | `false` | `ptr(false)` |
+
+**Rationale**: Per the MCP spec, `DestructiveHint` and `IdempotentHint` are only meaningful when `ReadOnlyHint` is false. All tentacular tools operate on a closed Kubernetes cluster, so `OpenWorldHint` is `ptr(false)` for all tools. Using `ptr(false)` for write-tier `DestructiveHint` explicitly signals "non-destructive write" rather than relying on the nil default (which means "true" per spec).
+
+**Alternative considered**: Omitting `OpenWorldHint` entirely (nil defaults to true per spec). Rejected because all tools interact with a bounded Kubernetes cluster, not an open-ended external system. Explicit `ptr(false)` is more accurate.
+
+### D2: IdempotentHint classification
+
+Tools where repeated calls with the same arguments produce no additional side effects get `IdempotentHint: true`:
+
+- `wf_apply` (re-applying the same manifest is a no-op in Kubernetes)
+- `ns_create` (will fail or no-op if namespace exists)
+- `ns_update` (re-applying same labels/annotations is idempotent)
+- `gvisor_annotate_ns` (re-annotating is idempotent)
+- `cred_kubeconfig` (generates same output for same inputs)
+
+Tools that are NOT idempotent:
+- `wf_run` (creates a new workflow run each time)
+- `wf_restart` (triggers a new restart each time)
+- `cred_issue_token` (generates a new token each time)
+- `gvisor_verify` (runs a verification pod each time)
+- `wf_remove`, `ns_delete`, `cred_rotate` (destructive, second call may fail)
+
+**Rationale**: Kubernetes API semantics make most create/update operations idempotent. Token generation and workflow runs are inherently non-idempotent.
+
+### D3: Helper function for bool pointers
+
+Introduce a file-scoped helper `boolPtr(b bool) *bool` in a shared location (e.g., top of `register.go` or a new `annotations.go` helper file) to construct `*bool` values for `DestructiveHint` and `OpenWorldHint`.
+
+**Rationale**: Go requires taking the address of a variable to get `*bool`; inline `&[]bool{true}[0]` is unreadable. A helper keeps the registration code clean.
+
+**Alternative considered**: Using package-level `var` sentinels (`var trueVal = true`). Rejected because a function is more idiomatic and avoids mutable package state.
+
+### D4: Title format convention
+
+Titles use sentence case, action-oriented phrasing: "List managed namespaces", "Delete a managed namespace", "Get cluster health summary". This matches the MCP spec recommendation that `Title` be human-readable display text.
+
+### D5: Description enrichment strategy
+
+Enhance descriptions with a consistent structure:
+1. One-sentence summary of what the tool does (already exists)
+2. Prerequisites or constraints (e.g., "Only works on tentacular-managed namespaces")
+3. Expected effects for write/destructive tools (e.g., "Creates namespace, network policy, resource quota, and RBAC resources")
+4. Safety note for destructive tools (e.g., "Permanently removes the namespace and all resources within it")
+
+Keep descriptions concise -- no more than 2-3 sentences total. Agents consume these in context windows.
+
+**Alternative considered**: Adding structured metadata fields beyond what MCP supports. Rejected because the MCP spec already provides the annotation fields needed, and description text is the standard channel for behavioral guidance.
+
+### D6: Test approach
+
+Add a table-driven test in `register_test.go` that:
+1. Registers all tools via `RegisterAll()` on a test server
+2. Calls `tools/list` to get the registered tools
+3. Asserts every tool has non-nil `Annotations`
+4. Asserts specific classification per tool name using a map of expected annotations
+5. Asserts every tool has a non-empty `Title`
+
+This approach catches regressions if new tools are added without annotations.
+
+**Alternative considered**: Per-file unit tests for each tool's annotations. Rejected because a single table-driven test is more maintainable and catches the "forgot to annotate a new tool" failure mode.
+
+### D7: File organization
+
+Modify tool registrations in-place within each existing file (`namespace.go`, `workflow.go`, etc.) rather than centralizing annotations in a separate file. Add the `boolPtr` helper to `register.go`.
+
+**Rationale**: Keeping annotations co-located with tool definitions makes it easy to see the full tool specification at a glance. A separate annotations file would scatter the tool definition across two locations.
+
+## Risks / Trade-offs
+
+**[Risk] Annotation drift when new tools are added** -- A developer might add a new tool without annotations, regressing the safety classification coverage.
+Mitigation: The table-driven test (D6) will fail if any registered tool lacks annotations, catching this in CI.
+
+**[Risk] Incorrect classification leads to false safety signals** -- If a destructive tool is marked read-only, an agent may call it without user confirmation.
+Mitigation: The test includes per-tool expected values, not just "has annotations". Code review should verify classifications against actual handler behavior.
+
+**[Risk] SDK upgrade changes ToolAnnotations semantics** -- Future SDK versions might alter default values or add new fields.
+Mitigation: The SDK is pinned at v1.3.1 in go.mod. Any upgrade will require reviewing annotation semantics.
+
+**[Trade-off] Description length vs. context window cost** -- Richer descriptions consume more tokens in agent context. We keep descriptions to 2-3 sentences maximum to balance informativeness with token efficiency.
+
+**[Trade-off] OpenWorldHint false for all tools** -- Some tools (e.g., `cluster_preflight`) interact with external registries or endpoints. We classify as closed-world because the primary interaction domain is the Kubernetes cluster. This could be revisited per-tool if agents need finer-grained open-world classification.
+
+## Open Questions
+
+1. **exo_list inclusion**: The proposal listed 35 tools but the codebase has 36 (including `exo_list`). Confirm `exo_list` should be classified as Read-only (ReadOnlyHint: true) alongside `exo_status` and `exo_registration`.
+
+2. **gvisor_verify classification**: Currently classified as Write (non-destructive) because it creates a temporary verification pod. Should it be Read-only since the pod is ephemeral and the intent is verification, not mutation? The current classification (Write, non-destructive, non-idempotent) seems correct since it does create a resource.

--- a/openspec/changes/mcp-tool-annotations/proposal.md
+++ b/openspec/changes/mcp-tool-annotations/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The MCP specification supports ToolAnnotations (ReadOnlyHint, DestructiveHint, IdempotentHint, OpenWorldHint) for safety classification, but the tentacular-mcp server registers all 35 tools without any annotations. Agents cannot auto-classify tool safety from introspection and must rely on hardcoded knowledge in skill docs. Adding annotations enables agents to discover tool risk levels dynamically, reducing misuse and enabling the skill restructuring in tentacular-skill to reference introspectable safety data rather than maintaining a static classification table.
+
+## What Changes
+
+- Add MCP ToolAnnotations to all 35 tool registrations in `pkg/tools/`, classified into three tiers:
+  - **Read** (ReadOnlyHint: true, 23 tools): wf_list, wf_describe, wf_status, wf_health, wf_health_ns, wf_pods, wf_logs, wf_events, wf_jobs, ns_get, ns_list, health_nodes, health_ns_usage, health_cluster_summary, audit_rbac, audit_netpol, audit_psa, gvisor_check, exo_status, exo_registration, proxy_status, cluster_profile, cluster_preflight
+  - **Write** (DestructiveHint: false explicitly, 9 tools): wf_apply, wf_restart, wf_run, ns_create, ns_update, gvisor_annotate_ns, gvisor_verify, cred_issue_token, cred_kubeconfig
+  - **Destructive** (DestructiveHint: true, 3 tools): wf_remove, ns_delete, cred_rotate
+- Enrich tool descriptions with behavioral guidance (expected effects, confirmation patterns)
+- Add/update tests in register_test.go to verify annotations are set correctly on every tool
+
+## Capabilities
+
+### New Capabilities
+- `tool-annotations`: MCP ToolAnnotation support for all registered tools, including ReadOnlyHint, DestructiveHint, IdempotentHint, and OpenWorldHint classification
+- `tool-description-enrichment`: Enhanced tool descriptions with behavioral guidance for agent consumption
+
+### Modified Capabilities
+- `workflow-introspection`: Tool registrations for wf_* tools gain ToolAnnotations (ReadOnlyHint for read ops, DestructiveHint for wf_remove)
+- `namespace-lifecycle`: Tool registrations for ns_* tools gain ToolAnnotations (DestructiveHint: true for ns_delete)
+- `credential-management`: Tool registrations for cred_* tools gain ToolAnnotations (DestructiveHint: true for cred_rotate)
+- `security-audit`: Tool registrations for audit_* tools gain ToolAnnotations (ReadOnlyHint: true)
+- `gvisor-sandbox`: Tool registrations for gvisor_* tools gain ToolAnnotations
+- `cluster-health`: Tool registrations for health_* tools gain ToolAnnotations (ReadOnlyHint: true)
+- `cluster-ops`: Tool registrations for cluster_profile and cluster_preflight gain ToolAnnotations (ReadOnlyHint: true)
+- `module-proxy`: Tool registration for proxy_status gains ToolAnnotations (ReadOnlyHint: true)
+
+## Impact
+
+- **pkg/tools/*.go** -- all tool registration files updated to include ToolAnnotations structs
+- **pkg/tools/register_test.go** -- new or updated test cases verifying annotation correctness for all 35 tools
+- **MCP protocol surface** -- tools.list responses will now include annotations; this is additive and non-breaking for existing clients
+- **Cross-repo dependency** -- tentacular-skill's references/mcp-tools.md (from skill-restructure-accuracy change) will reference these annotations as the source of truth for tool safety classification

--- a/openspec/changes/mcp-tool-annotations/specs/cluster-health/spec.md
+++ b/openspec/changes/mcp-tool-annotations/specs/cluster-health/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Report node health
+The system SHALL return the health status of all cluster nodes including name, ready condition, CPU/memory capacity, CPU/memory allocatable, kubelet version, and any node conditions that are not healthy (e.g., MemoryPressure, DiskPressure, PIDPressure). The `health_nodes` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Report node health"`.
+
+#### Scenario: All nodes healthy
+- **WHEN** the `health_nodes` tool is called and all nodes are Ready
+- **THEN** the system returns a list of nodes with `ready: true` and their capacity/allocatable resources
+
+#### Scenario: Node with pressure condition
+- **WHEN** the `health_nodes` tool is called and a node has MemoryPressure=True
+- **THEN** the system returns that node with `ready: true` (or false if NotReady) and includes the pressure condition in a `conditions` list
+
+#### Scenario: health_nodes tool annotations are read-only
+- **WHEN** the `health_nodes` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`
+
+### Requirement: Report namespace resource usage
+The system SHALL return resource utilization for a given namespace, comparing actual usage against the ResourceQuota limits. The response SHALL include CPU and memory used vs. limit, pod count vs. limit, and a utilization percentage for each resource. The system SHALL reject the operation if the target namespace is `tentacular-system`. The `health_ns_usage` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Report namespace resource usage"`.
+
+#### Scenario: Namespace with quota and active workloads
+- **WHEN** the `health_ns_usage` tool is called with `namespace: "dev-alice"` and the namespace has a quota and running pods
+- **THEN** the system returns used CPU, used memory, pod count, their respective quota limits, and utilization percentages
+
+#### Scenario: Namespace without quota
+- **WHEN** the `health_ns_usage` tool is called for a namespace without a ResourceQuota
+- **THEN** the system returns usage figures with limits shown as "unlimited"
+
+#### Scenario: health_ns_usage tool annotations are read-only
+- **WHEN** the `health_ns_usage` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`
+
+### Requirement: Report cluster resource summary
+The system SHALL return an aggregate cluster resource summary including total/allocatable/requested CPU and memory across all nodes, total node count, ready node count, and total pod count across all namespaces. The `health_cluster_summary` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Report cluster resource summary"`.
+
+#### Scenario: Multi-node cluster summary
+- **WHEN** the `health_cluster_summary` tool is called on a 3-node cluster
+- **THEN** the system returns aggregated capacity, allocatable, and requested totals for CPU and memory, node count (3 total, N ready), and total pod count
+
+#### Scenario: health_cluster_summary tool annotations are read-only
+- **WHEN** the `health_cluster_summary` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`

--- a/openspec/changes/mcp-tool-annotations/specs/cluster-ops/spec.md
+++ b/openspec/changes/mcp-tool-annotations/specs/cluster-ops/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Run preflight checks
+The system SHALL run a series of validation checks for a given namespace and return structured results. Checks SHALL include: API server reachability, namespace existence, RBAC permissions for the workflow ServiceAccount (deployments, services, configmaps, secrets, cronjobs, jobs), and gVisor RuntimeClass availability. Each check result SHALL include name, pass/fail status, and optional warning and remediation text. The system SHALL reject the operation if the target namespace is `tentacular-system`. The `cluster_preflight` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Run preflight checks"`.
+
+#### Scenario: All checks pass
+- **WHEN** the `cluster_preflight` tool is called with `namespace: "dev-alice"` and all prerequisites are met
+- **THEN** the system returns a list of check results, all with `passed: true`
+
+#### Scenario: Some checks fail
+- **WHEN** the `cluster_preflight` tool is called and the namespace does not exist
+- **THEN** the system returns check results with `namespace-exists` marked as `passed: false` with a remediation message
+
+#### Scenario: gVisor not installed
+- **WHEN** the `cluster_preflight` tool is called and no gVisor RuntimeClass exists
+- **THEN** the `gvisor-runtime` check returns `passed: true` with a warning that gVisor is not available
+
+#### Scenario: cluster_preflight tool annotations are read-only
+- **WHEN** the `cluster_preflight` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`
+
+### Requirement: Generate cluster profile
+The system SHALL produce a comprehensive snapshot of cluster capabilities including: Kubernetes version, detected distribution (EKS/GKE/AKS/K3s/vanilla), node inventory with OS/arch/capacity/allocatable, RuntimeClass list with gVisor detection, CNI identification with network policy support flags, StorageClass list with default and RWX capability flags, CSI driver list, detected extensions (istio, cert-manager, prometheus, external-secrets, argocd, gateway-api), ingress resources (networking.k8s.io), workload topology (replicasets, daemonsets, statefulsets), storage posture (persistentvolumes, persistentvolumeclaims, volumeattachments), service discovery (endpoints, endpointslices), and namespace-level details (pod security level, quota summary, limit range summary). The ClusterRole SHALL include the `watch` verb on all profiling resources to support event streaming. The system SHALL reject the operation if the target namespace is `tentacular-system`. The `cluster_profile` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Generate cluster profile"`.
+
+#### Scenario: Profile a cluster with namespace context
+- **WHEN** the `cluster_profile` tool is called with `namespace: "dev-alice"`
+- **THEN** the system returns a ClusterProfile JSON object with all sections populated, including namespace-specific quota and limit range data
+
+#### Scenario: Profile a cluster without namespace
+- **WHEN** the `cluster_profile` tool is called without a namespace parameter
+- **THEN** the system returns a ClusterProfile JSON object with cluster-wide data and the namespace-specific sections omitted
+
+#### Scenario: cluster_profile tool annotations are read-only
+- **WHEN** the `cluster_profile` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`

--- a/openspec/changes/mcp-tool-annotations/specs/credential-management/spec.md
+++ b/openspec/changes/mcp-tool-annotations/specs/credential-management/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Issue short-lived ServiceAccount token
+The system SHALL issue a time-bound token for the `tentacular-workflow` ServiceAccount in a given namespace using the Kubernetes TokenRequest API. The TTL SHALL be specified in minutes and MUST be between 10 and 1440 (24 hours). The system SHALL reject the operation if the target namespace is `tentacular-system`. The `cred_issue_token` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: false`, `DestructiveHint: ptr(false)`, `IdempotentHint: false`, `OpenWorldHint: ptr(false)`, and `Title: "Issue service account token"`.
+
+#### Scenario: Issue token with valid TTL
+- **WHEN** the `cred_issue_token` tool is called with `namespace: "dev-alice"` and `ttl_minutes: 60`
+- **THEN** the system returns a JWT token string valid for 60 minutes scoped to the workflow ServiceAccount in `dev-alice`
+
+#### Scenario: Reject TTL out of range
+- **WHEN** the `cred_issue_token` tool is called with `ttl_minutes: 5`
+- **THEN** the system returns an error indicating the TTL must be between 10 and 1440 minutes
+
+#### Scenario: Reject protected namespace
+- **WHEN** the `cred_issue_token` tool is called with `namespace: "tentacular-system"`
+- **THEN** the system returns an error indicating operations on `tentacular-system` are not allowed
+
+#### Scenario: cred_issue_token tool annotations are non-destructive non-idempotent write
+- **WHEN** the `cred_issue_token` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false`, `annotations.destructiveHint` is `false`, and `annotations.idempotentHint` is `false`
+
+### Requirement: Generate scoped kubeconfig
+The system SHALL generate a complete kubeconfig YAML string containing the cluster CA, API server URL, issued token, and target namespace. The kubeconfig SHALL use context name `tentacular` and user name `tentacular-workflow`. The system SHALL call the token issuance internally with the specified TTL. The `cred_kubeconfig` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: false`, `DestructiveHint: ptr(false)`, `IdempotentHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Generate scoped kubeconfig"`.
+
+#### Scenario: Generate kubeconfig
+- **WHEN** the `cred_kubeconfig` tool is called with `namespace: "dev-alice"` and `ttl_minutes: 120`
+- **THEN** the system returns a valid kubeconfig YAML with the cluster endpoint, CA data, a token valid for 120 minutes, and the namespace set to `dev-alice`
+
+#### Scenario: cred_kubeconfig tool annotations are non-destructive idempotent write
+- **WHEN** the `cred_kubeconfig` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false`, `annotations.destructiveHint` is `false`, and `annotations.idempotentHint` is `true`
+
+### Requirement: Rotate credentials
+The system SHALL rotate credentials for a namespace by deleting and recreating the `tentacular-workflow` ServiceAccount, which invalidates all previously issued tokens. The system SHALL reject the operation if the target namespace is `tentacular-system`. The `cred_rotate` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: false`, `DestructiveHint: ptr(true)`, `IdempotentHint: false`, `OpenWorldHint: ptr(false)`, and `Title: "Rotate namespace credentials"`. The description SHALL include a safety note about token invalidation.
+
+#### Scenario: Successful credential rotation
+- **WHEN** the `cred_rotate` tool is called with `namespace: "dev-alice"`
+- **THEN** the system deletes the existing workflow ServiceAccount and creates a new one, and all previously issued tokens for that ServiceAccount become invalid
+
+#### Scenario: ServiceAccount does not exist
+- **WHEN** the `cred_rotate` tool is called for a namespace where the ServiceAccount was never created
+- **THEN** the system creates the ServiceAccount (idempotent behavior)
+
+#### Scenario: cred_rotate tool annotations are destructive
+- **WHEN** the `cred_rotate` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false` and `annotations.destructiveHint` is `true`

--- a/openspec/changes/mcp-tool-annotations/specs/gvisor-sandbox/spec.md
+++ b/openspec/changes/mcp-tool-annotations/specs/gvisor-sandbox/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Check gVisor availability
+The system SHALL check whether a gVisor-compatible RuntimeClass (handler `gvisor` or `runsc`) exists in the cluster and return its name, handler, and availability status. The `gvisor_check` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Check gVisor availability"`.
+
+#### Scenario: gVisor RuntimeClass exists
+- **WHEN** the `gvisor_check` tool is called and a RuntimeClass with handler `runsc` exists
+- **THEN** the system returns `available: true` with the RuntimeClass name and handler
+
+#### Scenario: gVisor not installed
+- **WHEN** the `gvisor_check` tool is called and no gVisor RuntimeClass exists
+- **THEN** the system returns `available: false` with installation guidance
+
+#### Scenario: gvisor_check tool annotations are read-only
+- **WHEN** the `gvisor_check` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`
+
+### Requirement: Annotate namespace with gVisor runtime class
+The system SHALL annotate a managed namespace to indicate gVisor sandboxing is desired by adding the annotation `tentacular.io/runtime-class: gvisor`. This annotation signals to workflow deployments that pods SHOULD use the gVisor RuntimeClass. The system SHALL verify the namespace is managed by tentacular and reject the operation if the target namespace is `tentacular-system`. The `gvisor_annotate_ns` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: false`, `DestructiveHint: ptr(false)`, `IdempotentHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Enable gVisor for namespace"`.
+
+#### Scenario: Annotate managed namespace with gVisor
+- **WHEN** the `gvisor_annotate_ns` tool is called with `namespace: "dev-alice"` and the namespace is managed
+- **THEN** the system adds the `tentacular.io/runtime-class: gvisor` annotation to the namespace
+
+#### Scenario: Reject for unmanaged namespace
+- **WHEN** the `gvisor_annotate_ns` tool is called for a namespace without the managed-by label
+- **THEN** the system returns an error indicating the namespace is not managed by tentacular
+
+#### Scenario: gVisor not available in cluster
+- **WHEN** the `gvisor_annotate_ns` tool is called and no gVisor RuntimeClass exists
+- **THEN** the system returns an error indicating gVisor is not available in the cluster
+
+#### Scenario: gvisor_annotate_ns tool annotations are non-destructive idempotent write
+- **WHEN** the `gvisor_annotate_ns` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false`, `annotations.destructiveHint` is `false`, and `annotations.idempotentHint` is `true`
+
+### Requirement: Verify gVisor sandbox
+The system SHALL launch a short-lived verification pod in the target namespace using the gVisor RuntimeClass, run `dmesg | head -1` inside it, confirm the output contains "gVisor" or "runsc", and clean up the pod. The system SHALL reject the operation if the target namespace is `tentacular-system`. The `gvisor_verify` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: false`, `DestructiveHint: ptr(false)`, `IdempotentHint: false`, `OpenWorldHint: ptr(false)`, and `Title: "Verify gVisor sandbox"`.
+
+#### Scenario: gVisor verification succeeds
+- **WHEN** the `gvisor_verify` tool is called with `namespace: "dev-alice"` and gVisor is functional
+- **THEN** the system returns `verified: true` with the dmesg output confirming gVisor
+
+#### Scenario: gVisor verification fails
+- **WHEN** the `gvisor_verify` tool is called and the verification pod output does not contain gVisor markers
+- **THEN** the system returns `verified: false` with the actual dmesg output for debugging
+
+#### Scenario: Verification pod times out
+- **WHEN** the `gvisor_verify` tool is called and the verification pod does not reach Running state within 60 seconds
+- **THEN** the system returns an error indicating the verification timed out and cleans up the pod
+
+#### Scenario: gvisor_verify tool annotations are non-destructive non-idempotent write
+- **WHEN** the `gvisor_verify` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false`, `annotations.destructiveHint` is `false`, and `annotations.idempotentHint` is `false`

--- a/openspec/changes/mcp-tool-annotations/specs/module-proxy/spec.md
+++ b/openspec/changes/mcp-tool-annotations/specs/module-proxy/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Apply module release
+The system SHALL apply a set of Kubernetes manifests to a managed namespace using the dynamic client, tracking all created/updated resources with a release label (`tentacular.io/release: <name>`). The input SHALL include the deployment name, namespace, and a list of Kubernetes resource manifests as unstructured JSON/YAML. The ClusterRole SHALL grant `create,update,delete,patch,get,list,watch` verbs on all module resource types including deployments, services, configmaps, secrets, jobs, cronjobs, networkpolicies, and ingresses (networking.k8s.io). The `patch` verb is required for incremental updates (strategic merge patches). The `watch` verb supports status monitoring. The system SHALL validate that the namespace is managed by tentacular and reject the operation if the target namespace is `tentacular-system`. The `wf_apply` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: false`, `DestructiveHint: ptr(false)`, `IdempotentHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Apply module release"`. The description SHALL mention that a managed namespace is required.
+
+#### Scenario: Apply new release
+- **WHEN** the `wf_apply` tool is called with `namespace: "dev-alice"`, `name: "my-app"`, and a list of manifests
+- **THEN** the system creates all resources in the namespace, labels them with `tentacular.io/release: my-app`, and returns the count of created resources
+
+#### Scenario: Update existing release
+- **WHEN** the `wf_apply` tool is called with a name that already has resources in the namespace
+- **THEN** the system applies the manifests (create or update), labels them, and removes any previously-labeled resources that are no longer in the manifest set
+
+#### Scenario: Reject for unmanaged namespace
+- **WHEN** the `wf_apply` tool is called for a namespace without the managed-by label
+- **THEN** the system returns an error indicating the namespace is not managed by tentacular
+
+#### Scenario: wf_apply tool annotations are non-destructive idempotent write
+- **WHEN** the `wf_apply` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false`, `annotations.destructiveHint` is `false`, and `annotations.idempotentHint` is `true`
+
+### Requirement: Remove module release
+The system SHALL delete all resources labeled with `tentacular.io/release: <name>` in the given namespace. The system SHALL validate the namespace is managed and reject the operation if the target namespace is `tentacular-system`. The `wf_remove` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: false`, `DestructiveHint: ptr(true)`, `IdempotentHint: false`, `OpenWorldHint: ptr(false)`, and `Title: "Remove module release"`. The description SHALL include a safety note about permanent resource deletion.
+
+#### Scenario: Remove existing release
+- **WHEN** the `wf_remove` tool is called with `namespace: "dev-alice"` and `name: "my-app"`
+- **THEN** the system deletes all resources with the `tentacular.io/release: my-app` label and returns the count of deleted resources
+
+#### Scenario: Release not found
+- **WHEN** the `wf_remove` tool is called with a name that has no matching resources
+- **THEN** the system returns a success response with zero resources deleted
+
+#### Scenario: wf_remove tool annotations are destructive
+- **WHEN** the `wf_remove` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false` and `annotations.destructiveHint` is `true`
+
+### Requirement: Get module release status
+The system SHALL list all resources in a namespace labeled with `tentacular.io/release: <name>` and return their kind, name, and readiness status. The system SHALL reject the operation if the target namespace is `tentacular-system`. The `wf_status` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Get module release status"`.
+
+#### Scenario: Get status of healthy release
+- **WHEN** the `wf_status` tool is called with `namespace: "dev-alice"` and `name: "my-app"` and all resources are ready
+- **THEN** the system returns a list of resources with kind, name, and `ready: true` for each
+
+#### Scenario: Get status with unhealthy resources
+- **WHEN** the `wf_status` tool is called and some Deployments have unavailable replicas
+- **THEN** the system returns resources with `ready: false` for the unhealthy ones, including a reason string
+
+#### Scenario: wf_status tool annotations are read-only
+- **WHEN** the `wf_status` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`

--- a/openspec/changes/mcp-tool-annotations/specs/namespace-lifecycle/spec.md
+++ b/openspec/changes/mcp-tool-annotations/specs/namespace-lifecycle/spec.md
@@ -1,0 +1,72 @@
+## MODIFIED Requirements
+
+### Requirement: Create managed namespace
+The system SHALL create a Kubernetes namespace with the `app.kubernetes.io/managed-by: tentacular` label and Pod Security Admission labels set to `restricted` profile at `latest` version. The system SHALL also create a default-deny NetworkPolicy, a DNS-allow NetworkPolicy, a ResourceQuota (from a named preset), a LimitRange with default container resource requests/limits, a workflow ServiceAccount, a workflow Role, and a workflow RoleBinding in the new namespace. The workflow Role SHALL grant `create,update,delete,patch,get,list,watch` on apps/deployments, core/services+configmaps+secrets, batch/cronjobs+jobs, networking.k8s.io/networkpolicies+ingresses; `get,list,watch` on core/pods+pods/log+events; and `get,list,patch,update` on core/serviceaccounts (for imagePullSecrets management). The system SHALL reject the operation if the target namespace is `tentacular-system`. The `ns_create` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: false`, `DestructiveHint: ptr(false)`, `IdempotentHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Create managed namespace"`. The description SHALL mention the resources created (namespace, network policies, resource quotas, RBAC).
+
+#### Scenario: Successful namespace creation with small quota
+- **WHEN** the `ns_create` tool is called with `name: "dev-alice"` and `quota_preset: "small"`
+- **THEN** the system creates namespace `dev-alice` with managed-by label, PSA restricted labels, default-deny and DNS-allow NetworkPolicies, a ResourceQuota with CPU=2, Mem=2Gi, Pods=10, a LimitRange, and the workflow ServiceAccount/Role/RoleBinding
+
+#### Scenario: Reject creation of protected namespace
+- **WHEN** the `ns_create` tool is called with `name: "tentacular-system"`
+- **THEN** the system returns an error indicating operations on `tentacular-system` are not allowed
+
+#### Scenario: Namespace already exists
+- **WHEN** the `ns_create` tool is called with a name that already exists
+- **THEN** the system returns an error indicating the namespace already exists
+
+#### Scenario: ns_create tool annotations are non-destructive idempotent write
+- **WHEN** the `ns_create` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false`, `annotations.destructiveHint` is `false`, and `annotations.idempotentHint` is `true`
+
+### Requirement: Delete managed namespace
+The system SHALL delete a namespace only if it carries the `app.kubernetes.io/managed-by: tentacular` label. The system SHALL reject deletion of `tentacular-system`. Deleting a namespace removes all resources within it (Kubernetes garbage collection). The `ns_delete` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: false`, `DestructiveHint: ptr(true)`, `IdempotentHint: false`, `OpenWorldHint: ptr(false)`, and `Title: "Delete managed namespace"`. The description SHALL include a safety note about permanent removal.
+
+#### Scenario: Successful deletion of managed namespace
+- **WHEN** the `ns_delete` tool is called with `name: "dev-alice"` and the namespace has the managed-by label
+- **THEN** the system deletes the namespace
+
+#### Scenario: Reject deletion of unmanaged namespace
+- **WHEN** the `ns_delete` tool is called with a namespace that lacks the managed-by label
+- **THEN** the system returns an error indicating the namespace is not managed by tentacular
+
+#### Scenario: Reject deletion of protected namespace
+- **WHEN** the `ns_delete` tool is called with `name: "tentacular-system"`
+- **THEN** the system returns an error indicating operations on `tentacular-system` are not allowed
+
+#### Scenario: ns_delete tool annotations are destructive
+- **WHEN** the `ns_delete` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false` and `annotations.destructiveHint` is `true`
+
+### Requirement: Get namespace details
+The system SHALL retrieve a single namespace by name and return its metadata, labels, annotations, status, resource quota usage, and limit range configuration. The system SHALL reject the operation if the target is `tentacular-system`. The `ns_get` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Get namespace details"`.
+
+#### Scenario: Get existing namespace
+- **WHEN** the `ns_get` tool is called with `name: "dev-alice"`
+- **THEN** the system returns the namespace metadata, labels, annotations, status, quota summary, and limit range summary
+
+#### Scenario: ns_get tool annotations are read-only
+- **WHEN** the `ns_get` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`
+
+### Requirement: List managed namespaces
+The system SHALL list all namespaces that carry the `app.kubernetes.io/managed-by: tentacular` label. The `ns_list` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "List managed namespaces"`.
+
+#### Scenario: List namespaces
+- **WHEN** the `ns_list` tool is called
+- **THEN** the system returns all namespaces with the managed-by label
+
+#### Scenario: ns_list tool annotations are read-only
+- **WHEN** the `ns_list` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`
+
+### Requirement: Update managed namespace
+The system SHALL update labels, annotations, or resource quota preset on a managed namespace. The `ns_update` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: false`, `DestructiveHint: ptr(false)`, `IdempotentHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Update managed namespace"`.
+
+#### Scenario: Update namespace labels
+- **WHEN** the `ns_update` tool is called with new labels
+- **THEN** the system merges the labels onto the namespace
+
+#### Scenario: ns_update tool annotations are non-destructive idempotent write
+- **WHEN** the `ns_update` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false`, `annotations.destructiveHint` is `false`, and `annotations.idempotentHint` is `true`

--- a/openspec/changes/mcp-tool-annotations/specs/security-audit/spec.md
+++ b/openspec/changes/mcp-tool-annotations/specs/security-audit/spec.md
@@ -1,0 +1,94 @@
+## MODIFIED Requirements
+
+### Requirement: Audit RBAC for over-permissions
+The system SHALL scan all Roles and RoleBindings in a given namespace and flag any rules that grant wildcard verbs (`*`), wildcard resources (`*`), access to sensitive resources (secrets, serviceaccounts/token, pods/exec, pods/attach), or escalation verbs (`bind`, `escalate`, `impersonate`). The system SHALL return a list of findings, each with the role name, the problematic rule, a severity level (high/medium/low), and a remediation suggestion. The system SHALL reject the operation if the target namespace is `tentacular-system`. The `audit_rbac` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Audit RBAC permissions"`.
+
+#### Scenario: Namespace with over-permissioned role
+- **WHEN** the `audit_rbac` tool is called with `namespace: "dev-alice"` and a Role grants `*` verbs on secrets
+- **THEN** the system returns a finding with severity `high`, the role name, the flagged rule, and a remediation suggestion
+
+#### Scenario: Namespace with clean RBAC
+- **WHEN** the `audit_rbac` tool is called and all Roles follow least-privilege principles
+- **THEN** the system returns an empty findings list
+
+#### Scenario: Also inspect ClusterRoleBindings targeting namespace
+- **WHEN** the `audit_rbac` tool is called and a ClusterRoleBinding grants a ClusterRole to a ServiceAccount in the target namespace
+- **THEN** the system includes any over-permissioned rules from the bound ClusterRole in the findings
+
+#### Scenario: Detect escalation via bind verb
+- **WHEN** the `audit_rbac` tool is called and a Role grants the `bind` verb on roles or clusterroles
+- **THEN** the system returns a finding with severity `high` indicating privilege escalation risk and a remediation to remove the verb
+
+#### Scenario: Detect escalation via escalate verb
+- **WHEN** the `audit_rbac` tool is called and a Role grants the `escalate` verb
+- **THEN** the system returns a finding with severity `high` indicating the role can modify its own permissions
+
+#### Scenario: Detect impersonation capability
+- **WHEN** the `audit_rbac` tool is called and a Role grants the `impersonate` verb on users, groups, or serviceaccounts
+- **THEN** the system returns a finding with severity `high` indicating identity impersonation risk
+
+#### Scenario: audit_rbac tool annotations are read-only
+- **WHEN** the `audit_rbac` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`
+
+### Requirement: Audit network policy coverage
+The system SHALL verify that a namespace has at least a default-deny NetworkPolicy (denying all ingress and egress) and report on all NetworkPolicies present. The system SHALL flag namespaces that allow unrestricted egress, have no NetworkPolicies at all, contain overly broad allow rules that negate default-deny, or allow cross-namespace ingress via empty `namespaceSelector`. The system SHALL return findings with remediation suggestions. The system SHALL reject the operation if the target namespace is `tentacular-system`. The `audit_netpol` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Audit network policies"`.
+
+#### Scenario: Namespace with default-deny policy
+- **WHEN** the `audit_netpol` tool is called with `namespace: "dev-alice"` and a default-deny policy exists
+- **THEN** the system returns `default_deny: true` and lists all NetworkPolicies with their policy types and pod selectors
+
+#### Scenario: Namespace without network policies
+- **WHEN** the `audit_netpol` tool is called and no NetworkPolicies exist in the namespace
+- **THEN** the system returns `default_deny: false` with a finding flagging the namespace as having unrestricted network access and a remediation suggestion
+
+#### Scenario: Namespace with partial coverage
+- **WHEN** the `audit_netpol` tool is called and the namespace has ingress policies but no egress restriction
+- **THEN** the system returns `default_deny: false` with a finding noting unrestricted egress
+
+#### Scenario: Overly broad ingress allow rule
+- **WHEN** the `audit_netpol` tool is called and a NetworkPolicy has an ingress rule with an empty peer (`from: [{}]`) that allows traffic from all sources
+- **THEN** the system returns a finding with severity `high` indicating the rule negates default-deny
+
+#### Scenario: Overly broad egress allow rule
+- **WHEN** the `audit_netpol` tool is called and a NetworkPolicy has an egress rule with an empty peer (`to: [{}]`) that allows traffic to all destinations
+- **THEN** the system returns a finding with severity `high` indicating the rule negates default-deny
+
+#### Scenario: Cross-namespace ingress via empty namespaceSelector
+- **WHEN** the `audit_netpol` tool is called and a NetworkPolicy allows ingress from all namespaces via an empty `namespaceSelector`
+- **THEN** the system returns a finding with severity `medium` recommending restricting the selector
+
+#### Scenario: audit_netpol tool annotations are read-only
+- **WHEN** the `audit_netpol` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`
+
+### Requirement: Audit Pod Security Admission labels
+The system SHALL check the Pod Security Admission labels on a namespace and report the enforce, audit, and warn levels. The system SHALL flag namespaces that do not have PSA enforce set to `restricted` or that have no PSA labels at all. The system SHALL treat `privileged` enforce level as high severity (all checks disabled) and `baseline` as medium severity. The system SHALL detect when audit or warn levels are weaker than the enforce level. The system SHALL return findings with remediation suggestions. The system SHALL reject the operation if the target namespace is `tentacular-system`. The `audit_psa` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Audit pod security admission"`.
+
+#### Scenario: Namespace with restricted PSA
+- **WHEN** the `audit_psa` tool is called with `namespace: "dev-alice"` and PSA enforce is `restricted` with matching audit and warn levels
+- **THEN** the system returns `compliant: true` with the enforce, audit, and warn levels and no findings
+
+#### Scenario: Namespace with privileged PSA
+- **WHEN** the `audit_psa` tool is called and PSA enforce is `privileged`
+- **THEN** the system returns `compliant: false` with a high-severity finding indicating all pod security checks are disabled
+
+#### Scenario: Namespace with baseline PSA
+- **WHEN** the `audit_psa` tool is called and PSA enforce is `baseline`
+- **THEN** the system returns `compliant: false` with a medium-severity finding recommending upgrade to `restricted`
+
+#### Scenario: Namespace with no PSA labels
+- **WHEN** the `audit_psa` tool is called and no PSA labels exist on the namespace
+- **THEN** the system returns `compliant: false` with a high-severity finding noting the absence of PSA configuration
+
+#### Scenario: Audit level weaker than enforce
+- **WHEN** the `audit_psa` tool is called and the audit level is weaker than the enforce level (e.g. enforce=restricted, audit=baseline)
+- **THEN** the system returns a medium-severity finding noting the audit log will not capture all violations
+
+#### Scenario: Warn level weaker than enforce
+- **WHEN** the `audit_psa` tool is called and the warn level is weaker than the enforce level
+- **THEN** the system returns a medium-severity finding noting users will not see warnings for all enforced restrictions
+
+#### Scenario: audit_psa tool annotations are read-only
+- **WHEN** the `audit_psa` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`

--- a/openspec/changes/mcp-tool-annotations/specs/tool-annotations/spec.md
+++ b/openspec/changes/mcp-tool-annotations/specs/tool-annotations/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Every registered tool SHALL have ToolAnnotations
+The system SHALL set a non-nil `ToolAnnotations` struct on every `mcp.Tool` passed to `mcp.AddTool()`. No tool registration SHALL omit the `Annotations` field.
+
+#### Scenario: All tools have annotations after registration
+- **WHEN** `RegisterAll()` is called and the server's tool list is retrieved via `tools/list`
+- **THEN** every tool in the response has a non-nil `annotations` field
+
+#### Scenario: New tool added without annotations fails CI
+- **WHEN** a developer adds a new tool via `mcp.AddTool()` without setting `Annotations`
+- **THEN** the annotation coverage test in `register_test.go` fails
+
+### Requirement: Every tool SHALL have a Title annotation
+The system SHALL set a non-empty `Title` field on every tool's `ToolAnnotations`. Titles SHALL use sentence case and action-oriented phrasing (e.g., "List managed namespaces", "Delete a managed namespace").
+
+#### Scenario: All tools have titles
+- **WHEN** the server's tool list is retrieved via `tools/list`
+- **THEN** every tool has a non-empty `annotations.title` field
+
+### Requirement: Read-only tools SHALL be annotated with ReadOnlyHint true
+The system SHALL set `ReadOnlyHint: true` on all tools that do not modify cluster state. Read-only tools are: wf_list, wf_describe, wf_status, wf_health, wf_health_ns, wf_pods, wf_logs, wf_events, wf_jobs, ns_get, ns_list, health_nodes, health_ns_usage, health_cluster_summary, audit_rbac, audit_netpol, audit_psa, gvisor_check, exo_status, exo_registration, exo_list, proxy_status, cluster_profile, cluster_preflight.
+
+#### Scenario: Read-only tool has ReadOnlyHint true
+- **WHEN** the tool `wf_list` is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true`
+
+#### Scenario: Read-only tool does not set DestructiveHint
+- **WHEN** the tool `ns_list` is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.destructiveHint` is nil (not meaningful for read-only tools)
+
+### Requirement: Write tools SHALL be annotated with DestructiveHint false
+The system SHALL set `DestructiveHint: ptr(false)` on tools that modify cluster state but are not destructive. Write tools are: wf_apply, wf_restart, wf_run, ns_create, ns_update, gvisor_annotate_ns, gvisor_verify, cred_issue_token, cred_kubeconfig.
+
+#### Scenario: Write tool has DestructiveHint false
+- **WHEN** the tool `wf_apply` is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false` and `annotations.destructiveHint` is `false`
+
+#### Scenario: Write tool ReadOnlyHint is false
+- **WHEN** the tool `ns_create` is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false`
+
+### Requirement: Destructive tools SHALL be annotated with DestructiveHint true
+The system SHALL set `DestructiveHint: ptr(true)` on tools that permanently remove or irreversibly modify resources. Destructive tools are: wf_remove, ns_delete, cred_rotate.
+
+#### Scenario: Destructive tool has DestructiveHint true
+- **WHEN** the tool `wf_remove` is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false` and `annotations.destructiveHint` is `true`
+
+#### Scenario: ns_delete is destructive
+- **WHEN** the tool `ns_delete` is retrieved from the server's tool list
+- **THEN** `annotations.destructiveHint` is `true`
+
+#### Scenario: cred_rotate is destructive
+- **WHEN** the tool `cred_rotate` is retrieved from the server's tool list
+- **THEN** `annotations.destructiveHint` is `true`
+
+### Requirement: Idempotent tools SHALL be annotated with IdempotentHint true
+The system SHALL set `IdempotentHint: true` on write tools where repeated calls with the same arguments produce no additional side effects. Idempotent write tools are: wf_apply, ns_create, ns_update, gvisor_annotate_ns, cred_kubeconfig.
+
+#### Scenario: Idempotent write tool
+- **WHEN** the tool `wf_apply` is retrieved from the server's tool list
+- **THEN** `annotations.idempotentHint` is `true`
+
+#### Scenario: Non-idempotent write tool
+- **WHEN** the tool `wf_run` is retrieved from the server's tool list
+- **THEN** `annotations.idempotentHint` is `false`
+
+### Requirement: All tools SHALL have OpenWorldHint false
+The system SHALL set `OpenWorldHint: ptr(false)` on all tools because all tools interact with a bounded Kubernetes cluster, not an open-ended external system.
+
+#### Scenario: Tool has closed-world annotation
+- **WHEN** any tool is retrieved from the server's tool list
+- **THEN** `annotations.openWorldHint` is `false`
+
+### Requirement: Bool pointer helper for ToolAnnotations
+The system SHALL provide a helper function `boolPtr(b bool) *bool` in `pkg/tools/` for constructing `*bool` values used by `DestructiveHint` and `OpenWorldHint` fields.
+
+#### Scenario: Helper returns pointer to true
+- **WHEN** `boolPtr(true)` is called
+- **THEN** the returned `*bool` points to a value of `true`
+
+#### Scenario: Helper returns pointer to false
+- **WHEN** `boolPtr(false)` is called
+- **THEN** the returned `*bool` points to a value of `false`

--- a/openspec/changes/mcp-tool-annotations/specs/tool-description-enrichment/spec.md
+++ b/openspec/changes/mcp-tool-annotations/specs/tool-description-enrichment/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Write tool descriptions SHALL include expected effects
+The system SHALL enrich the `Description` field of all write and destructive tools with a brief statement of expected effects. Descriptions SHALL remain concise (2-3 sentences maximum).
+
+#### Scenario: Write tool description includes effects
+- **WHEN** the tool `ns_create` description is retrieved
+- **THEN** the description mentions the resources that will be created (namespace, network policies, resource quotas, RBAC)
+
+#### Scenario: Destructive tool description includes safety note
+- **WHEN** the tool `ns_delete` description is retrieved
+- **THEN** the description includes a note about permanent removal of the namespace and its contents
+
+#### Scenario: Destructive tool cred_rotate description includes safety note
+- **WHEN** the tool `cred_rotate` description is retrieved
+- **THEN** the description includes a note about credential invalidation
+
+### Requirement: Tool descriptions SHALL include prerequisite constraints
+The system SHALL enrich tool descriptions with prerequisite or constraint information where applicable (e.g., "Only works on tentacular-managed namespaces", "Namespace must exist").
+
+#### Scenario: Namespace tool includes managed-by constraint
+- **WHEN** the tool `ns_delete` description is retrieved
+- **THEN** the description mentions that only tentacular-managed namespaces can be deleted
+
+#### Scenario: Workflow tool includes namespace prerequisite
+- **WHEN** the tool `wf_apply` description is retrieved
+- **THEN** the description mentions that a managed namespace is required
+
+### Requirement: Descriptions SHALL NOT exceed three sentences
+The system SHALL keep all tool descriptions to three sentences or fewer to minimize token consumption in agent context windows.
+
+#### Scenario: Description length check
+- **WHEN** any tool description is retrieved from the server's tool list
+- **THEN** the description contains no more than three sentences

--- a/openspec/changes/mcp-tool-annotations/specs/workflow-introspection/spec.md
+++ b/openspec/changes/mcp-tool-annotations/specs/workflow-introspection/spec.md
@@ -1,0 +1,88 @@
+## MODIFIED Requirements
+
+### Requirement: List pods in namespace
+The system SHALL list all pods in a given namespace, returning pod name, phase, ready condition, restart count, container images, and age. The ClusterRole SHALL include the `watch` verb on pods and events to support future event streaming for `wf_pods` and `wf_events`. The system SHALL reject the operation if the target namespace is `tentacular-system`. The `wf_pods` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "List pods in namespace"`.
+
+#### Scenario: List pods with running workloads
+- **WHEN** the `wf_pods` tool is called with `namespace: "dev-alice"` and pods exist
+- **THEN** the system returns a list of pods with name, phase, ready status, restart count, images, and creation timestamp
+
+#### Scenario: No pods in namespace
+- **WHEN** the `wf_pods` tool is called with `namespace: "dev-alice"` and no pods exist
+- **THEN** the system returns an empty list
+
+#### Scenario: wf_pods tool annotations are read-only
+- **WHEN** the `wf_pods` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`
+
+### Requirement: Tail pod logs
+The system SHALL retrieve the most recent log lines from a specified container in a pod. The caller MAY specify `tail_lines` (default 100) and an optional `container` name. If the pod has a single container, the container parameter MAY be omitted. The system SHALL reject the operation if the target namespace is `tentacular-system`. The `wf_logs` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "Tail pod logs"`.
+
+#### Scenario: Tail logs from single-container pod
+- **WHEN** the `wf_logs` tool is called with `namespace: "dev-alice"`, `pod: "web-abc123"`, and `tail_lines: 50`
+- **THEN** the system returns the last 50 log lines from the pod's only container
+
+#### Scenario: Tail logs from specific container in multi-container pod
+- **WHEN** the `wf_logs` tool is called with `namespace: "dev-alice"`, `pod: "web-abc123"`, `container: "sidecar"`, and `tail_lines: 20`
+- **THEN** the system returns the last 20 log lines from the `sidecar` container
+
+#### Scenario: Pod not found
+- **WHEN** the `wf_logs` tool is called with a pod name that does not exist
+- **THEN** the system returns an error indicating the pod was not found
+
+#### Scenario: wf_logs tool annotations are read-only
+- **WHEN** the `wf_logs` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`
+
+### Requirement: List namespace events
+The system SHALL list recent events in a namespace, returning type (Normal/Warning), reason, message, involved object, count, and last timestamp. Results SHALL be sorted by last timestamp descending and limited to the most recent 100 events by default. The system SHALL reject the operation if the target namespace is `tentacular-system`. The `wf_events` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "List namespace events"`.
+
+#### Scenario: List events with warnings present
+- **WHEN** the `wf_events` tool is called with `namespace: "dev-alice"`
+- **THEN** the system returns events sorted by last timestamp descending, each with type, reason, message, involved object reference, count, and timestamp
+
+#### Scenario: No events in namespace
+- **WHEN** the `wf_events` tool is called and no events exist in the namespace
+- **THEN** the system returns an empty list
+
+#### Scenario: wf_events tool annotations are read-only
+- **WHEN** the `wf_events` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`
+
+### Requirement: List jobs and cronjobs
+The system SHALL list all Jobs and CronJobs in a namespace. For Jobs, return name, status (active/succeeded/failed), start time, completion time, and duration. For CronJobs, return name, schedule, last schedule time, active count, and suspend status. The system SHALL reject the operation if the target namespace is `tentacular-system`. The `wf_jobs` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: true`, `OpenWorldHint: ptr(false)`, and `Title: "List jobs and cronjobs"`.
+
+#### Scenario: List jobs and cronjobs
+- **WHEN** the `wf_jobs` tool is called with `namespace: "dev-alice"`
+- **THEN** the system returns separate lists of Jobs and CronJobs with their respective status fields
+
+#### Scenario: No jobs or cronjobs
+- **WHEN** the `wf_jobs` tool is called and no Jobs or CronJobs exist
+- **THEN** the system returns empty lists for both Jobs and CronJobs
+
+#### Scenario: wf_jobs tool annotations are read-only
+- **WHEN** the `wf_jobs` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `true` and `annotations.openWorldHint` is `false`
+
+### Requirement: Rollout restart a deployment
+The system SHALL perform a rollout restart of a Deployment in a managed namespace by patching the pod template with a `tentacular.io/restartedAt` annotation containing the current UTC timestamp. This is the same mechanism as `kubectl rollout restart`. The system SHALL verify the namespace is managed by tentacular and that the deployment exists before patching. The system SHALL reject the operation if the target namespace is `tentacular-system` or if the namespace is not managed by tentacular. The `wf_restart` tool registration SHALL include `ToolAnnotations` with `ReadOnlyHint: false`, `DestructiveHint: ptr(false)`, `IdempotentHint: false`, `OpenWorldHint: ptr(false)`, and `Title: "Restart a deployment"`.
+
+#### Scenario: Successful rollout restart
+- **WHEN** the `wf_restart` tool is called with `namespace: "dev-alice"` and `deployment: "web-app"` and the namespace is managed
+- **THEN** the system patches the deployment's pod template with a `tentacular.io/restartedAt` annotation and returns `restarted: true`
+
+#### Scenario: Reject restart in unmanaged namespace
+- **WHEN** the `wf_restart` tool is called with a namespace that is not managed by tentacular
+- **THEN** the system returns an error indicating the namespace is not managed
+
+#### Scenario: Deployment not found
+- **WHEN** the `wf_restart` tool is called with a deployment name that does not exist in the namespace
+- **THEN** the system returns an error indicating the deployment was not found
+
+#### Scenario: Reject restart in protected namespace
+- **WHEN** the `wf_restart` tool is called with `namespace: "tentacular-system"`
+- **THEN** the system returns an error indicating operations on `tentacular-system` are not allowed
+
+#### Scenario: wf_restart tool annotations are non-destructive write
+- **WHEN** the `wf_restart` tool is retrieved from the server's tool list
+- **THEN** `annotations.readOnlyHint` is `false`, `annotations.destructiveHint` is `false`, and `annotations.idempotentHint` is `false`

--- a/openspec/changes/mcp-tool-annotations/tasks.md
+++ b/openspec/changes/mcp-tool-annotations/tasks.md
@@ -1,0 +1,56 @@
+## 1. Helper Infrastructure
+
+- [ ] 1.1 Add `boolPtr(b bool) *bool` helper function to `pkg/tools/register.go`
+- [ ] 1.2 Verify the helper compiles and is accessible from all tool registration files in the package
+
+## 2. Read-Only Tool Annotations
+
+- [ ] 2.1 Add ToolAnnotations to `wf_list`, `wf_describe`, `wf_status` in `pkg/tools/workflow.go` (ReadOnlyHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 2.2 Add ToolAnnotations to `wf_pods`, `wf_logs` in `pkg/tools/workflow.go` (ReadOnlyHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 2.3 Add ToolAnnotations to `wf_events`, `wf_jobs` in `pkg/tools/discover.go` (ReadOnlyHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 2.4 Add ToolAnnotations to `wf_health`, `wf_health_ns` in `pkg/tools/wf_health.go` (ReadOnlyHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 2.5 Add ToolAnnotations to `ns_get`, `ns_list` in `pkg/tools/namespace.go` (ReadOnlyHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 2.6 Add ToolAnnotations to `health_nodes`, `health_ns_usage`, `health_cluster_summary` in `pkg/tools/health.go` (ReadOnlyHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 2.7 Add ToolAnnotations to `audit_rbac`, `audit_netpol`, `audit_psa` in `pkg/tools/audit.go` (ReadOnlyHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 2.8 Add ToolAnnotations to `gvisor_check` in `pkg/tools/gvisor.go` (ReadOnlyHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 2.9 Add ToolAnnotations to `exo_status`, `exo_registration`, `exo_list` in `pkg/tools/exoskeleton.go` (ReadOnlyHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 2.10 Add ToolAnnotations to `cluster_profile`, `cluster_preflight` in `pkg/tools/clusterops.go` (ReadOnlyHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 2.11 Add ToolAnnotations to `proxy_status` in `pkg/tools/proxy.go` (ReadOnlyHint: true, OpenWorldHint: ptr(false), Title)
+
+## 3. Write (Non-Destructive) Tool Annotations
+
+- [ ] 3.1 Add ToolAnnotations to `wf_apply` in `pkg/tools/deploy.go` (DestructiveHint: ptr(false), IdempotentHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 3.2 Add ToolAnnotations to `wf_restart` in `pkg/tools/deploy.go` (DestructiveHint: ptr(false), IdempotentHint: false, OpenWorldHint: ptr(false), Title)
+- [ ] 3.3 Add ToolAnnotations to `wf_run` in `pkg/tools/run.go` (DestructiveHint: ptr(false), IdempotentHint: false, OpenWorldHint: ptr(false), Title)
+- [ ] 3.4 Add ToolAnnotations to `ns_create` in `pkg/tools/namespace.go` (DestructiveHint: ptr(false), IdempotentHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 3.5 Add ToolAnnotations to `ns_update` in `pkg/tools/namespace.go` (DestructiveHint: ptr(false), IdempotentHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 3.6 Add ToolAnnotations to `gvisor_annotate_ns` in `pkg/tools/gvisor.go` (DestructiveHint: ptr(false), IdempotentHint: true, OpenWorldHint: ptr(false), Title)
+- [ ] 3.7 Add ToolAnnotations to `gvisor_verify` in `pkg/tools/gvisor.go` (DestructiveHint: ptr(false), IdempotentHint: false, OpenWorldHint: ptr(false), Title)
+- [ ] 3.8 Add ToolAnnotations to `cred_issue_token` in `pkg/tools/credential.go` (DestructiveHint: ptr(false), IdempotentHint: false, OpenWorldHint: ptr(false), Title)
+- [ ] 3.9 Add ToolAnnotations to `cred_kubeconfig` in `pkg/tools/credential.go` (DestructiveHint: ptr(false), IdempotentHint: true, OpenWorldHint: ptr(false), Title)
+
+## 4. Destructive Tool Annotations
+
+- [ ] 4.1 Add ToolAnnotations to `wf_remove` in `pkg/tools/deploy.go` (DestructiveHint: ptr(true), IdempotentHint: false, OpenWorldHint: ptr(false), Title)
+- [ ] 4.2 Add ToolAnnotations to `ns_delete` in `pkg/tools/namespace.go` (DestructiveHint: ptr(true), IdempotentHint: false, OpenWorldHint: ptr(false), Title)
+- [ ] 4.3 Add ToolAnnotations to `cred_rotate` in `pkg/tools/credential.go` (DestructiveHint: ptr(true), IdempotentHint: false, OpenWorldHint: ptr(false), Title)
+
+## 5. Description Enrichment
+
+- [ ] 5.1 Enrich descriptions for write tools (wf_apply, wf_restart, wf_run, ns_create, ns_update, gvisor_annotate_ns, gvisor_verify, cred_issue_token, cred_kubeconfig) with expected effects and prerequisites
+- [ ] 5.2 Enrich descriptions for destructive tools (wf_remove, ns_delete, cred_rotate) with safety notes about permanent removal or invalidation
+- [ ] 5.3 Review all descriptions to verify none exceed three sentences
+
+## 6. Test Coverage
+
+- [ ] 6.1 Add table-driven test in `pkg/tools/register_test.go` that calls `tools/list` and asserts every tool has non-nil Annotations
+- [ ] 6.2 Add per-tool expected annotation map verifying ReadOnlyHint, DestructiveHint, IdempotentHint, OpenWorldHint, and Title for all 36 tools
+- [ ] 6.3 Add assertion that fails if a new tool is registered without annotations (count check)
+- [ ] 6.4 Run `go test ./pkg/tools/...` and verify all tests pass
+
+## 7. Validation
+
+- [ ] 7.1 Run `go build ./...` to verify compilation
+- [ ] 7.2 Run `go vet ./...` to check for issues
+- [ ] 7.3 Run golangci-lint if configured
+- [ ] 7.4 Manually verify one tool from each tier via `tools/list` JSON output (if test cluster available)

--- a/pkg/tools/audit.go
+++ b/pkg/tools/audit.go
@@ -84,6 +84,13 @@ func registerAuditTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "audit_rbac",
 		Description: "Audit RBAC in a namespace: scan for wildcard verbs/resources, sensitive access, escalation paths (bind/escalate/impersonate verbs), and ClusterRoleBindings targeting namespace service accounts. Returns findings with remediation suggestions.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Audit RBAC Configuration",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params AuditRbacParams) (*mcp.CallToolResult, AuditRbacResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, AuditRbacResult{}, err
@@ -95,6 +102,13 @@ func registerAuditTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "audit_netpol",
 		Description: "Audit network policies in a namespace: check for default-deny policy, missing egress restrictions, overly broad allow rules, cross-namespace ingress via empty namespaceSelector, and list all policies. Returns findings with remediation suggestions.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Audit Network Policies",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params AuditNetpolParams) (*mcp.CallToolResult, AuditNetpolResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, AuditNetpolResult{}, err
@@ -106,6 +120,13 @@ func registerAuditTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "audit_psa",
 		Description: "Audit Pod Security Admission labels on a namespace: check enforce/audit/warn levels, flag privileged or missing enforcement, detect audit/warn level mismatches, and return remediation suggestions.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Audit Pod Security Admission",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params AuditPsaParams) (*mcp.CallToolResult, AuditPsaResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, AuditPsaResult{}, err

--- a/pkg/tools/clusterops.go
+++ b/pkg/tools/clusterops.go
@@ -29,6 +29,13 @@ func registerClusterOpsTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "cluster_preflight",
 		Description: "Run preflight checks for a namespace: API reachability, namespace existence, RBAC, and gVisor availability.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Run Cluster Preflight Checks",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params ClusterPreflightParams) (*mcp.CallToolResult, ClusterPreflightResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, ClusterPreflightResult{}, err
@@ -40,6 +47,13 @@ func registerClusterOpsTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "cluster_profile",
 		Description: "Profile the cluster: K8s version, distribution, nodes, runtime classes, CNI, storage, and extensions.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Profile Cluster Capabilities",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params ClusterProfileParams) (*mcp.CallToolResult, *k8s.ClusterProfile, error) {
 		if params.Namespace != "" {
 			if err := guard.CheckNamespace(params.Namespace); err != nil {

--- a/pkg/tools/credential.go
+++ b/pkg/tools/credential.go
@@ -50,6 +50,13 @@ func registerCredentialTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "cred_issue_token",
 		Description: "Issue a short-lived token for the tentacular-workflow service account in a namespace.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Issue Service Account Token",
+			ReadOnlyHint:    false,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  false,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params CredIssueTokenParams) (*mcp.CallToolResult, CredIssueTokenResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, CredIssueTokenResult{}, err
@@ -61,6 +68,13 @@ func registerCredentialTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "cred_kubeconfig",
 		Description: "Generate a kubeconfig for the tentacular-workflow service account in a namespace.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Generate Scoped Kubeconfig",
+			ReadOnlyHint:    false,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  false,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params CredKubeconfigParams) (*mcp.CallToolResult, CredKubeconfigResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, CredKubeconfigResult{}, err
@@ -71,7 +85,14 @@ func registerCredentialTools(srv *mcp.Server, client *k8s.Client) {
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "cred_rotate",
-		Description: "Rotate the workflow service account in a namespace, invalidating all existing tokens.",
+		Description: "Rotate the workflow service account in a namespace by recreating it. Invalidates all existing tokens for the service account.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Rotate Service Account",
+			ReadOnlyHint:    false,
+			DestructiveHint: boolPtr(true),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params CredRotateParams) (*mcp.CallToolResult, CredRotateResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, CredRotateResult{}, err

--- a/pkg/tools/deploy.go
+++ b/pkg/tools/deploy.go
@@ -136,7 +136,14 @@ type WorkflowStatusResult struct {
 func registerDeployTools(srv *mcp.Server, client *k8s.Client, sched *scheduler.Scheduler, exoCtrl *exoskeleton.Controller) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_apply",
-		Description: "Apply a set of Kubernetes manifests as a named deployment in a namespace. Uses release labels for tracking and garbage collection.",
+		Description: "Apply a set of Kubernetes manifests as a named deployment in a namespace. Uses release labels for tracking and garbage collection. Includes garbage collection of stale resources.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Apply Workflow Manifests",
+			ReadOnlyHint:    false,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WorkflowApplyParams) (*mcp.CallToolResult, WorkflowApplyResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WorkflowApplyResult{}, err
@@ -196,7 +203,14 @@ func registerDeployTools(srv *mcp.Server, client *k8s.Client, sched *scheduler.S
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_remove",
-		Description: "Remove all resources belonging to a named deployment in a namespace.",
+		Description: "Remove all resources belonging to a named deployment in a namespace. When exoskeleton cleanup is enabled, also drops backing-service data.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Remove Workflow Deployment",
+			ReadOnlyHint:    false,
+			DestructiveHint: boolPtr(true),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WorkflowRemoveParams) (*mcp.CallToolResult, WorkflowRemoveResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WorkflowRemoveResult{}, err
@@ -225,6 +239,13 @@ func registerDeployTools(srv *mcp.Server, client *k8s.Client, sched *scheduler.S
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_status",
 		Description: "Get status of all resources belonging to a named deployment in a namespace.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Get Workflow Status",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WorkflowStatusParams) (*mcp.CallToolResult, WorkflowStatusResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WorkflowStatusResult{}, err

--- a/pkg/tools/discover.go
+++ b/pkg/tools/discover.go
@@ -92,6 +92,13 @@ func registerDiscoverTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_list",
 		Description: "List all tentacular-managed workflow deployments across namespaces, with ownership and status.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "List Deployed Workflows",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WfListParams) (*mcp.CallToolResult, WfListResult, error) {
 		if params.Namespace != "" {
 			if err := guard.CheckNamespace(params.Namespace); err != nil {
@@ -105,6 +112,13 @@ func registerDiscoverTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_describe",
 		Description: "Get detailed information about a single tentacular workflow deployment, including metadata annotations, replica status, nodes, and triggers.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Describe Workflow Deployment",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WfDescribeParams) (*mcp.CallToolResult, WfDescribeResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WfDescribeResult{}, err

--- a/pkg/tools/exoskeleton.go
+++ b/pkg/tools/exoskeleton.go
@@ -72,6 +72,13 @@ func registerExoskeletonTools(srv *mcp.Server, client *k8s.Client, ctrl *exoskel
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "exo_status",
 		Description: "Return exoskeleton feature status including which backing services are available.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Exoskeleton Service Status",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params ExoStatusParams) (*mcp.CallToolResult, ExoStatusResult, error) {
 		if ctrl == nil {
 			return nil, ExoStatusResult{Enabled: false, Services: []ExoStatusServiceInfo{}}, nil
@@ -94,6 +101,13 @@ func registerExoskeletonTools(srv *mcp.Server, client *k8s.Client, ctrl *exoskel
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "exo_registration",
 		Description: "Return exoskeleton registration details (Secret contents) for a workflow deployment.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Workflow Exo Registration",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params ExoRegistrationParams) (*mcp.CallToolResult, ExoRegistrationResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, ExoRegistrationResult{}, err
@@ -136,6 +150,13 @@ func registerExoskeletonTools(srv *mcp.Server, client *k8s.Client, ctrl *exoskel
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "exo_list",
 		Description: "List all workflows with exoskeleton registrations by scanning Secrets with the exoskeleton label across all namespaces.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "List Exo Registrations",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params ExoListParams) (*mcp.CallToolResult, ExoListResult, error) {
 		result, err := handleExoList(ctx, client)
 		return nil, result, err

--- a/pkg/tools/gvisor.go
+++ b/pkg/tools/gvisor.go
@@ -56,6 +56,13 @@ func registerGVisorTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "gvisor_check",
 		Description: "Check whether a gVisor RuntimeClass is available in the cluster.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Check gVisor Availability",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GVisorCheckParams) (*mcp.CallToolResult, GVisorCheckResult, error) {
 		result, err := handleGVisorCheck(ctx, client)
 		return nil, result, err
@@ -64,6 +71,13 @@ func registerGVisorTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "gvisor_annotate_ns",
 		Description: "Annotate a managed namespace with the gVisor runtime class so new pods use gVisor sandboxing.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Annotate Namespace for gVisor",
+			ReadOnlyHint:    false,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GVisorAnnotateNsParams) (*mcp.CallToolResult, GVisorAnnotateNsResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, GVisorAnnotateNsResult{}, err
@@ -74,7 +88,14 @@ func registerGVisorTools(srv *mcp.Server, client *k8s.Client) {
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "gvisor_verify",
-		Description: "Verify gVisor sandboxing by creating an ephemeral pod with the gVisor runtime class and checking kernel identity.",
+		Description: "Verify gVisor sandboxing by creating an ephemeral pod with the gVisor runtime class and checking kernel identity. Creates and deletes an ephemeral verification pod.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Verify gVisor Sandboxing",
+			ReadOnlyHint:    false,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params GVisorVerifyParams) (*mcp.CallToolResult, GVisorVerifyResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, GVisorVerifyResult{}, err

--- a/pkg/tools/health.go
+++ b/pkg/tools/health.go
@@ -78,6 +78,13 @@ func registerHealthTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "health_nodes",
 		Description: "List nodes with readiness, capacity, allocatable resources, kubelet version, and unhealthy conditions.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "List Node Health",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params HealthNodesParams) (*mcp.CallToolResult, HealthNodesResult, error) {
 		result, err := handleHealthNodes(ctx, client)
 		return nil, result, err
@@ -86,6 +93,13 @@ func registerHealthTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "health_ns_usage",
 		Description: "Compare namespace resource usage against ResourceQuota limits and return utilization percentages.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Namespace Resource Usage",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params HealthNsUsageParams) (*mcp.CallToolResult, HealthNsUsageResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, HealthNsUsageResult{}, err
@@ -97,6 +111,13 @@ func registerHealthTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "health_cluster_summary",
 		Description: "Aggregate cluster-wide CPU, memory, and pod counts across all nodes.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Cluster Resource Summary",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params HealthClusterSummaryParams) (*mcp.CallToolResult, HealthClusterSummaryResult, error) {
 		result, err := handleHealthClusterSummary(ctx, client)
 		return nil, result, err

--- a/pkg/tools/namespace.go
+++ b/pkg/tools/namespace.go
@@ -91,6 +91,13 @@ func registerNamespaceTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "ns_create",
 		Description: "Create a new managed namespace with network policies, resource quotas, and workflow RBAC.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Create Managed Namespace",
+			ReadOnlyHint:    false,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  false,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params NsCreateParams) (*mcp.CallToolResult, NsCreateResult, error) {
 		if err := guard.CheckNamespace(params.Name); err != nil {
 			return nil, NsCreateResult{}, err
@@ -102,6 +109,13 @@ func registerNamespaceTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "ns_delete",
 		Description: "Delete a managed namespace. Only namespaces with the tentacular managed-by label can be deleted.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Delete Managed Namespace",
+			ReadOnlyHint:    false,
+			DestructiveHint: boolPtr(true),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params NsDeleteParams) (*mcp.CallToolResult, NsDeleteResult, error) {
 		if err := guard.CheckNamespace(params.Name); err != nil {
 			return nil, NsDeleteResult{}, err
@@ -113,6 +127,13 @@ func registerNamespaceTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "ns_get",
 		Description: "Get details for a namespace including labels, status, quota summary, and limit range summary.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Get Namespace Details",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params NsGetParams) (*mcp.CallToolResult, NsGetResult, error) {
 		if err := guard.CheckNamespace(params.Name); err != nil {
 			return nil, NsGetResult{}, err
@@ -124,6 +145,13 @@ func registerNamespaceTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "ns_list",
 		Description: "List all namespaces managed by tentacular.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "List Managed Namespaces",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params NsListParams) (*mcp.CallToolResult, NsListResult, error) {
 		result, err := handleNsList(ctx, client)
 		return nil, result, err
@@ -132,6 +160,13 @@ func registerNamespaceTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "ns_update",
 		Description: "Update labels, annotations, or resource quota preset on a managed namespace.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Update Namespace Metadata",
+			ReadOnlyHint:    false,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params NsUpdateParams) (*mcp.CallToolResult, NsUpdateResult, error) {
 		if err := guard.CheckNamespace(params.Name); err != nil {
 			return nil, NsUpdateResult{}, err

--- a/pkg/tools/proxy.go
+++ b/pkg/tools/proxy.go
@@ -24,6 +24,13 @@ func registerProxyTools(srv *mcp.Server, reconciler *proxy.Reconciler) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "proxy_status",
 		Description: "Check the installation and readiness status of the module proxy (esm.sh).",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Module Proxy Status",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params ProxyStatusParams) (*mcp.CallToolResult, ProxyStatusResult, error) {
 		st := reconciler.GetStatus(ctx)
 		result := ProxyStatusResult{

--- a/pkg/tools/register.go
+++ b/pkg/tools/register.go
@@ -9,6 +9,10 @@ import (
 	"github.com/randybias/tentacular-mcp/pkg/scheduler"
 )
 
+// boolPtr returns a pointer to the given bool value.
+// Used for ToolAnnotations fields that require *bool (DestructiveHint, OpenWorldHint).
+func boolPtr(b bool) *bool { return &b }
+
 // RegisterAll registers all MCP tools with the given server.
 func RegisterAll(srv *mcp.Server, client *k8s.Client, reconciler *proxy.Reconciler, sched *scheduler.Scheduler, exoCtrl *exoskeleton.Controller) {
 	registerNamespaceTools(srv, client)

--- a/pkg/tools/run.go
+++ b/pkg/tools/run.go
@@ -31,6 +31,13 @@ func registerRunTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_run",
 		Description: "Trigger a deployed workflow by POSTing directly to its /run endpoint via HTTP. The MCP server connects to the workflow's ClusterIP service; NetworkPolicy allows ingress from tentacular-system via namespaceSelector. Returns the JSON output from the workflow.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Trigger Workflow Execution",
+			ReadOnlyHint:    false,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  false,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WfRunParams) (*mcp.CallToolResult, WfRunResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WfRunResult{}, err

--- a/pkg/tools/wf_health.go
+++ b/pkg/tools/wf_health.go
@@ -77,6 +77,13 @@ func registerWfHealthTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_health",
 		Description: "Get G/A/R health status of a single workflow runtime deployment, with optional execution telemetry.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Workflow Health Status",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WfHealthParams) (*mcp.CallToolResult, WfHealthResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WfHealthResult{}, err
@@ -88,6 +95,13 @@ func registerWfHealthTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_health_ns",
 		Description: "Aggregate G/A/R health status for all tentacular workflow deployments in a namespace.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Namespace Workflow Health",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WfHealthNsParams) (*mcp.CallToolResult, WfHealthNsResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WfHealthNsResult{}, err

--- a/pkg/tools/workflow.go
+++ b/pkg/tools/workflow.go
@@ -121,6 +121,13 @@ func registerWorkflowTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_pods",
 		Description: "List pods in a namespace with phase, readiness, restart count, images, and age.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "List Workflow Pods",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WfPodsParams) (*mcp.CallToolResult, WfPodsResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WfPodsResult{}, err
@@ -132,6 +139,13 @@ func registerWorkflowTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_logs",
 		Description: "Get pod logs from a namespace. Returns tail lines (default 100).",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Get Pod Logs",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WfLogsParams) (*mcp.CallToolResult, WfLogsResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WfLogsResult{}, err
@@ -146,6 +160,13 @@ func registerWorkflowTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_events",
 		Description: "List events in a namespace sorted by most recent first.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "List Namespace Events",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WfEventsParams) (*mcp.CallToolResult, WfEventsResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WfEventsResult{}, err
@@ -157,6 +178,13 @@ func registerWorkflowTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_jobs",
 		Description: "List Jobs and CronJobs in a namespace.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "List Jobs and CronJobs",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WfJobsParams) (*mcp.CallToolResult, WfJobsResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WfJobsResult{}, err
@@ -168,6 +196,13 @@ func registerWorkflowTools(srv *mcp.Server, client *k8s.Client) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_restart",
 		Description: "Rollout restart a deployment in a managed namespace by patching the pod template with a restart timestamp. Useful after ConfigMap/Secret changes, credential rotation, or gVisor enablement.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Restart Workflow Deployment",
+			ReadOnlyHint:    false,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(true),
+		},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, params WfRestartParams) (*mcp.CallToolResult, WfRestartResult, error) {
 		if err := guard.CheckNamespace(params.Namespace); err != nil {
 			return nil, WfRestartResult{}, err


### PR DESCRIPTION
## Summary

- Adds `ToolAnnotations` to all 36 MCP tools using the go-sdk v1.3.1 spec
- Classifies tools into 3 safety tiers: 24 read-only, 9 write (non-destructive), 3 destructive
- Enriches descriptions for 4 tools with behavioral guidance (wf_apply, wf_remove, gvisor_verify, cred_rotate)
- Adds `boolPtr` helper to `register.go`

## Motivation

The MCP spec supports safety hints (`ReadOnlyHint`, `DestructiveHint`, `IdempotentHint`, `OpenWorldHint`) but the server didn't use them. Adding annotations enables agents to auto-classify tool safety via `tools/list` introspection rather than relying on hardcoded skill documentation.

## Safety Classification

| Tier | Count | Tools |
|------|-------|-------|
| Read-only | 24 | ns_get, ns_list, wf_list, wf_describe, wf_status, wf_pods, wf_logs, wf_events, wf_jobs, wf_health, wf_health_ns, cluster_preflight, cluster_profile, health_*, audit_*, gvisor_check, exo_*, proxy_status |
| Write | 9 | ns_create, ns_update, wf_apply, wf_run, wf_restart, gvisor_annotate_ns, gvisor_verify, cred_issue_token, cred_kubeconfig |
| Destructive | 3 | ns_delete, wf_remove, cred_rotate |

## Cross-repo

Companion PR: randybias/tentacular-skill -- restructures the agent skill to consume these annotations as the source of truth for tool safety.

## Test plan

- [x] `make test` passes (all 8 packages, 0 failures)
- [x] All 36 tools have `Annotations` field set
- [x] Read-only tools have `ReadOnlyHint: true`
- [x] Destructive tools have `DestructiveHint: boolPtr(true)`
- [x] Write tools have `DestructiveHint: boolPtr(false)` explicitly
- [x] All tools have `OpenWorldHint: boolPtr(true)`
- [ ] Verify annotations visible via `tools/list` on deployed server

🤖 Generated with [Claude Code](https://claude.com/claude-code)