### PR TITLE
refactor: rename tentacular-catalog to tentacular-scaffolds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ In-cluster Go HTTP server that exposes MCP (Model Context Protocol) tools for AI
 | [tentacular](https://github.com/randybias/tentacular) | Go CLI (`tntc`) + Deno workflow engine |
 | [tentacular-mcp](https://github.com/randybias/tentacular-mcp) | In-cluster MCP server (this repo) |
 | [tentacular-skill](https://github.com/randybias/tentacular-skill) | Agent skill definition (Markdown) |
-| [tentacular-catalog](https://github.com/randybias/tentacular-catalog) | Workflow template catalog (TypeScript/Deno) |
+| [tentacular-scaffolds](https://github.com/randybias/tentacular-scaffolds) | Scaffold quickstart library (TypeScript/Deno) |
 
 ## System Architecture
 
@@ -25,7 +25,7 @@ Developer / AI Agent
     Kubernetes API
         |
     Workflow Pods             <-- Deno engine from tentacular/engine/
-        (gVisor sandbox)         Templates from tentacular-catalog
+        (gVisor sandbox)         Scaffolds from tentacular-scaffolds
 ```
 
 The CLI has zero direct Kubernetes API access. All cluster operations route through this MCP server via authenticated HTTP. The MCP server runs inside the cluster with scoped RBAC.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Developer workstations holding cluster-wide admin kubeconfig is a security anti-
 |------------|---------|
 | [tentacular](https://github.com/randybias/tentacular) | Go CLI + Deno workflow engine |
 | [tentacular-skill](https://github.com/randybias/tentacular-skill) | Agent skill definition for AI assistants |
-| [tentacular-catalog](https://github.com/randybias/tentacular-catalog) | Workflow template catalog |
+| [tentacular-scaffolds](https://github.com/randybias/tentacular-scaffolds) | Scaffold quickstart library |
 | [tentacular-docs](https://github.com/randybias/tentacular-docs) | [Documentation site](https://randybias.github.io/tentacular-docs) |
 
 ## Documentation


### PR DESCRIPTION
## Summary
- Update AGENTS.md and README.md references from tentacular-catalog to tentacular-scaffolds
- Docs-only change, part of the scaffold lifecycle redesign

🤖 Generated with [Claude Code](https://claude.com/claude-code)