### PR TITLE
docs: scaffold lifecycle - terminology update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ In-cluster Go HTTP server that exposes MCP (Model Context Protocol) tools for AI
 | [tentacular](https://github.com/randybias/tentacular) | Go CLI (`tntc`) + Deno workflow engine |
 | [tentacular-mcp](https://github.com/randybias/tentacular-mcp) | In-cluster MCP server (this repo) |
 | [tentacular-skill](https://github.com/randybias/tentacular-skill) | Agent skill definition (Markdown) |
-| [tentacular-scaffolds](https://github.com/randybias/tentacular-scaffolds) | Scaffold quickstart library (TypeScript/Deno) |
+| [tentacular-scaffolds](https://github.com/randybias/tentacular-scaffolds) | Workflow scaffold catalog / quickstarts (TypeScript/Deno) |
 
 ## System Architecture
 
@@ -108,7 +108,7 @@ All repos use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0
 feat: add workflow health endpoint
 fix: handle nil pod status in wf_pods
 test: add unit tests for discover handler
-docs: update CLI reference for catalog commands
+docs: update CLI reference for scaffold commands
 chore: bump Go to 1.25
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Developer workstations holding cluster-wide admin kubeconfig is a security anti-
 |------------|---------|
 | [tentacular](https://github.com/randybias/tentacular) | Go CLI + Deno workflow engine |
 | [tentacular-skill](https://github.com/randybias/tentacular-skill) | Agent skill definition for AI assistants |
-| [tentacular-scaffolds](https://github.com/randybias/tentacular-scaffolds) | Scaffold quickstart library |
+| [tentacular-scaffolds](https://github.com/randybias/tentacular-scaffolds) | Workflow scaffold catalog (quickstarts) |
 | [tentacular-docs](https://github.com/randybias/tentacular-docs) | [Documentation site](https://randybias.github.io/tentacular-docs) |
 
 ## Documentation


### PR DESCRIPTION
## Summary
- AGENTS.md and README.md updated: tentacular-catalog -> tentacular-scaffolds
- Docs-only change, no code modifications
- MCP server audit confirmed zero template/catalog references in Go source or API

## Test plan
- [x] Code review passed
- [x] grep confirms zero stale references

🤖 Generated with [Claude Code](https://claude.com/claude-code)