### PR TITLE
feat: add trusted AZPs for service-to-service OIDC auth

### DIFF
--- a/charts/tentacular-mcp/templates/deployment.yaml
+++ b/charts/tentacular-mcp/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
                   name: {{ include "tentacular-mcp.fullname" . }}-exoskeleton-auth
                   key: client-secret
             {{- end }}
+            {{- if .Values.exoskeletonAuth.trustedAZPs }}
+            - name: TENTACULAR_KEYCLOAK_TRUSTED_AZPS
+              value: {{ .Values.exoskeletonAuth.trustedAZPs | quote }}
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- if .Values.exoskeleton.enabled }}

--- a/charts/tentacular-mcp/values.yaml
+++ b/charts/tentacular-mcp/values.yaml
@@ -141,6 +141,9 @@ exoskeletonAuth:
   # -- Name of an existing Secret containing Keycloak credentials.
   # Required keys: issuer-url, client-id, client-secret.
   existingSecret: ""
+  # -- Comma-separated list of additional OIDC client IDs whose tokens
+  # are accepted (e.g. "thekraken" for service-to-service auth).
+  trustedAZPs: ""
 
 # -- Exoskeleton configuration for backing-service registration.
 exoskeleton:

--- a/pkg/exoskeleton/auth.go
+++ b/pkg/exoskeleton/auth.go
@@ -15,6 +15,10 @@ type AuthConfig struct {
 	ClientID     string
 	ClientSecret string
 	Enabled      bool
+	// TrustedAZPs lists additional OIDC client IDs whose tokens are accepted.
+	// This allows service-to-service callers (e.g. thekraken) to authenticate
+	// with their own client credentials while being accepted by the MCP server.
+	TrustedAZPs []string
 }
 
 // DeployerInfo contains identity information extracted from an OIDC token
@@ -31,9 +35,10 @@ type DeployerInfo struct {
 // OIDCValidator validates OIDC tokens using JWKS fetched from the issuer's
 // discovery endpoint.
 type OIDCValidator struct {
-	provider *oidc.Provider
-	verifier *oidc.IDTokenVerifier
-	clientID string
+	provider    *oidc.Provider
+	verifier    *oidc.IDTokenVerifier
+	clientID    string
+	trustedAZPs map[string]bool
 }
 
 // NewOIDCValidator creates a validator that fetches JWKS from the issuer and
@@ -62,12 +67,19 @@ func NewOIDCValidator(cfg AuthConfig) (*OIDCValidator, error) {
 		SkipClientIDCheck: true,
 	})
 
-	slog.Info("OIDC validator initialized", "issuer", cfg.IssuerURL, "client_id", cfg.ClientID)
+	trusted := make(map[string]bool)
+	trusted[cfg.ClientID] = true
+	for _, azp := range cfg.TrustedAZPs {
+		trusted[azp] = true
+	}
+
+	slog.Info("OIDC validator initialized", "issuer", cfg.IssuerURL, "client_id", cfg.ClientID, "trusted_azps", len(trusted))
 
 	return &OIDCValidator{
-		provider: provider,
-		verifier: verifier,
-		clientID: cfg.ClientID,
+		provider:    provider,
+		verifier:    verifier,
+		clientID:    cfg.ClientID,
+		trustedAZPs: trusted,
 	}, nil
 }
 
@@ -96,8 +108,8 @@ func (v *OIDCValidator) ValidateToken(ctx context.Context, tokenString string) (
 
 	// Validate azp (authorized party) since Keycloak access tokens use azp
 	// instead of aud for the client identifier.
-	if claims.AZP != v.clientID {
-		return nil, fmt.Errorf("OIDC token azp %q does not match client ID %q", claims.AZP, v.clientID)
+	if !v.trustedAZPs[claims.AZP] {
+		return nil, fmt.Errorf("OIDC token azp %q is not a trusted client (expected one of %v)", claims.AZP, v.trustedAZPs)
 	}
 
 	provider := determineProvider(claims)
@@ -120,14 +132,10 @@ func (v *OIDCValidator) ValidateToken(ctx context.Context, tokenString string) (
 
 // determineProvider infers the identity provider from the token claims.
 // Keycloak sets "identity_provider" when brokering (e.g., "google").
-// Otherwise we check the authorized party (azp) or default to "keycloak".
+// Service account tokens (no identity_provider) return "keycloak".
 func determineProvider(claims keycloakClaims) string {
 	if claims.IdentityProvider != "" {
 		return claims.IdentityProvider
-	}
-	// If azp looks like a Google client ID, it's likely Google SSO
-	if claims.AZP != "" && claims.AZP != "tentacular-mcp" {
-		return claims.AZP
 	}
 	return "keycloak"
 }

--- a/pkg/exoskeleton/auth.go
+++ b/pkg/exoskeleton/auth.go
@@ -14,11 +14,8 @@ type AuthConfig struct {
 	IssuerURL    string
 	ClientID     string
 	ClientSecret string
+	TrustedAZPs  []string
 	Enabled      bool
-	// TrustedAZPs lists additional OIDC client IDs whose tokens are accepted.
-	// This allows service-to-service callers (e.g. thekraken) to authenticate
-	// with their own client credentials while being accepted by the MCP server.
-	TrustedAZPs []string
 }
 
 // DeployerInfo contains identity information extracted from an OIDC token
@@ -35,10 +32,10 @@ type DeployerInfo struct {
 // OIDCValidator validates OIDC tokens using JWKS fetched from the issuer's
 // discovery endpoint.
 type OIDCValidator struct {
+	trustedAZPs map[string]bool
 	provider    *oidc.Provider
 	verifier    *oidc.IDTokenVerifier
 	clientID    string
-	trustedAZPs map[string]bool
 }
 
 // NewOIDCValidator creates a validator that fetches JWKS from the issuer and

--- a/pkg/exoskeleton/auth_test.go
+++ b/pkg/exoskeleton/auth_test.go
@@ -285,7 +285,7 @@ func TestDetermineProvider(t *testing.T) {
 		},
 		{
 			name:     "azp differs from our client",
-			expected: "some-other-client",
+			expected: "keycloak",
 			claims:   keycloakClaims{AZP: "some-other-client"},
 		},
 		{

--- a/pkg/exoskeleton/config.go
+++ b/pkg/exoskeleton/config.go
@@ -83,6 +83,7 @@ func LoadFromEnv() *Config {
 			IssuerURL:    os.Getenv("TENTACULAR_KEYCLOAK_ISSUER"),
 			ClientID:     os.Getenv("TENTACULAR_KEYCLOAK_CLIENT_ID"),
 			ClientSecret: os.Getenv("TENTACULAR_KEYCLOAK_CLIENT_SECRET"),
+			TrustedAZPs:  parseTrustedAZPs(os.Getenv("TENTACULAR_KEYCLOAK_TRUSTED_AZPS")),
 		},
 		SPIRE: SPIREConfig{
 			Enabled:   envBool("TENTACULAR_EXOSKELETON_SPIRE_ENABLED"),
@@ -195,6 +196,21 @@ func (c *Config) Validate() error {
 func envBool(key string) bool {
 	v := strings.ToLower(os.Getenv(key))
 	return v == "true" || v == "1" || v == "yes"
+}
+
+// parseTrustedAZPs splits a comma-separated list of OIDC client IDs.
+func parseTrustedAZPs(val string) []string {
+	if val == "" {
+		return nil
+	}
+	var result []string
+	for _, s := range strings.Split(val, ",") {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			result = append(result, s)
+		}
+	}
+	return result
 }
 
 // envDefault returns the value of the named environment variable, or

--- a/pkg/exoskeleton/config.go
+++ b/pkg/exoskeleton/config.go
@@ -11,8 +11,8 @@ type Config struct {
 	Postgres          PostgresConfig
 	RustFS            RustFSConfig
 	NATS              NATSConfig
-	Auth              AuthConfig
 	SPIRE             SPIREConfig
+	Auth              AuthConfig
 	Enabled           bool
 	CleanupOnUndeploy bool
 }


### PR DESCRIPTION
## Summary
- Add `TENTACULAR_KEYCLOAK_TRUSTED_AZPS` env var (comma-separated list) to allow additional OIDC client IDs to be accepted
- The Kraken uses its own Keycloak client (`thekraken`) with client_credentials grant for bot-level MCP calls, but the MCP server only accepted tokens with `azp: tentacular-mcp`
- Simplify `determineProvider()` — AZP is a client ID, not an identity provider

## Test plan
- [x] Unit tests pass (`go test ./pkg/exoskeleton/...`)
- [x] All package tests pass (`go test ./pkg/...`)
- [ ] Deploy with `TENTACULAR_KEYCLOAK_TRUSTED_AZPS=thekraken` and verify Kraken drift sync works
- [ ] Verify existing auth flows (Claude Code, tntc CLI) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)