### PR TITLE
ci(chart): add Azure CI values profile

### DIFF
--- a/charts/tentacular-platform/ci/azure-values.yaml
+++ b/charts/tentacular-platform/ci/azure-values.yaml
@@ -1,0 +1,37 @@
+# Azure production profile - K8s on Azure with nginx ingress + Azure LB
+# Layer ON TOP of prod-values.yaml. Overrides only Azure-specific settings.
+#
+# See prod-values.yaml for the full list of mandatory --set parameters.
+# Hostnames are auto-derived from global.domain:
+#   - tentacular-mcp.<domain>
+#   - tentacular-keycloak.<domain>
+#
+# Prerequisites:
+#   1. nginx ingress controller with Azure LB:
+#      helm install ingress-nginx ingress-nginx/ingress-nginx \
+#        -n ingress-nginx --create-namespace \
+#        --set controller.service.type=LoadBalancer \
+#        --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz
+#   2. cert-manager installed
+#   3. Default StorageClass set (e.g., managed-csi)
+#   4. DNS records pointing to the Azure LB:
+#      - tentacular-mcp.<your-domain>
+#      - tentacular-keycloak.<your-domain>
+
+# All hostnames are derived from global.domain (set via --set global.domain=<your-domain>)
+# No explicit hostname overrides needed in this file.
+
+tls:
+  clusterIssuers:
+    create: true
+    # Set via --set tls.clusterIssuers.email=admin@<your-domain>
+    production: true
+  certificates:
+    mcp:
+      create: true
+      secretName: tentacular-mcp-tls
+
+ingress:
+  tls:
+    enabled: true
+    secretName: tentacular-mcp-tls


### PR DESCRIPTION
## Summary
- Add `charts/tentacular-platform/ci/azure-values.yaml` — Azure production overlay for the platform Helm chart
- Mirrors the existing `aws-values.yaml` pattern: layers on top of `prod-values.yaml` with Azure-specific prerequisites (nginx ingress with Azure LB health probe, managed-csi StorageClass)
- Enables Let's Encrypt TLS via HTTP-01 solver with nginx IngressClass

## Test plan
- [x] Deployed full tentacular-platform stack on Azure k0s cluster (3 CP + 3 worker nodes) using `prod-values.yaml` + `azure-values.yaml`
- [x] All components running: MCP server, PostgreSQL, NATS, RustFS, Keycloak, esm-sh
- [x] Let's Encrypt production certificates issued for both MCP and Keycloak endpoints
- [x] Azure LoadBalancer provisioned via CCM for nginx ingress