### PR TITLE
fix: run OTel enrichment before exo-deps early return

### DIFF
--- a/pkg/exoskeleton/controller.go
+++ b/pkg/exoskeleton/controller.go
@@ -174,6 +174,13 @@ func (c *Controller) ProcessManifests(ctx context.Context, namespace, name strin
 		return manifests, nil
 	}
 
+	// OTel enrichment: unconditional — observability is a platform feature
+	// regardless of whether exoskeleton services are registered.
+	// Must run before the early return for workflows with no exo deps.
+	patchDeploymentOTelEnv(manifests)
+	patchDeploymentWorkflowLabel(manifests, name)
+	patchNetworkPolicyOTelEgress(manifests, name)
+
 	deps := detectExoDeps(manifests)
 	if len(deps) == 0 {
 		return manifests, nil
@@ -257,12 +264,6 @@ func (c *Controller) ProcessManifests(ctx context.Context, namespace, name strin
 			return nil, fmt.Errorf("merge exo creds: %w", err)
 		}
 	}
-
-	// OTel enrichment: unconditional — observability is a platform feature
-	// regardless of whether exoskeleton services are registered.
-	patchDeploymentOTelEnv(manifests)
-	patchDeploymentWorkflowLabel(manifests, name)
-	patchNetworkPolicyOTelEgress(manifests, name)
 
 	// SPIRE identity registration: creates a ClusterSPIFFEID so matching
 	// pods receive an X.509 SVID automatically. This does not produce


### PR DESCRIPTION
## Summary
- OTel enrichment (env vars, workflow label, NetworkPolicy egress) was gated behind `detectExoDeps()` early return
- Workflows without `tentacular-*` dependencies never got NetworkPolicy egress rules for the OTel collector
- Telemetry was silently dropped (port 4317/4318 blocked by NetworkPolicy)
- Move OTel patching before the early return so it runs unconditionally

## Validated
- ai-team-feed redeployed with fix, traces now flowing to ClickHouse
- All unit tests pass (`go test ./pkg/...`)

## Test plan
- [x] Unit tests pass
- [x] Deploy workflow without exo deps, verify NetworkPolicy has OTel egress
- [x] Verify traces appear in ClickHouse after workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)