### PR TITLE
feat: requests-based quota, raised presets, quota in enclave_sync

### DIFF
--- a/pkg/k8s/quota.go
+++ b/pkg/k8s/quota.go
@@ -10,7 +10,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// QuotaPreset defines resource limits for a namespace.
+// QuotaPreset defines resource quota for a namespace.
+// Quotas are set on requests (not limits) to allow bursty workloads.
+// Most tentacles are event-triggered and idle between runs, so the
+// request-based quota reflects actual scheduling demand while pods
+// are free to burst to their container limits during execution.
 type QuotaPreset struct {
 	CPU  string
 	Mem  string
@@ -18,9 +22,9 @@ type QuotaPreset struct {
 }
 
 var quotaPresets = map[string]QuotaPreset{
-	"small":  {CPU: "2", Mem: "2Gi", Pods: 10},
-	"medium": {CPU: "4", Mem: "8Gi", Pods: 20},
-	"large":  {CPU: "8", Mem: "16Gi", Pods: 50},
+	"small":  {CPU: "4", Mem: "4Gi", Pods: 20},
+	"medium": {CPU: "16", Mem: "16Gi", Pods: 50},
+	"large":  {CPU: "32", Mem: "64Gi", Pods: 100},
 }
 
 // CreateResourceQuota creates a ResourceQuota in the given namespace using
@@ -44,8 +48,8 @@ func CreateResourceQuota(ctx context.Context, client *Client, namespace, preset 
 		},
 		Spec: corev1.ResourceQuotaSpec{
 			Hard: corev1.ResourceList{
-				corev1.ResourceLimitsCPU:    resource.MustParse(p.CPU),
-				corev1.ResourceLimitsMemory: resource.MustParse(p.Mem),
+				corev1.ResourceRequestsCPU:    resource.MustParse(p.CPU),
+				corev1.ResourceRequestsMemory: resource.MustParse(p.Mem),
 				corev1.ResourcePods:         *resource.NewQuantity(p.Pods, resource.DecimalSI),
 			},
 		},
@@ -112,7 +116,7 @@ func CreateLimitRange(ctx context.Context, client *Client, namespace string) err
 				{
 					Type: corev1.LimitTypeContainer,
 					DefaultRequest: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceCPU:    resource.MustParse("50m"),
 						corev1.ResourceMemory: resource.MustParse("64Mi"),
 					},
 					Default: corev1.ResourceList{

--- a/pkg/k8s/quota.go
+++ b/pkg/k8s/quota.go
@@ -50,7 +50,7 @@ func CreateResourceQuota(ctx context.Context, client *Client, namespace, preset 
 			Hard: corev1.ResourceList{
 				corev1.ResourceRequestsCPU:    resource.MustParse(p.CPU),
 				corev1.ResourceRequestsMemory: resource.MustParse(p.Mem),
-				corev1.ResourcePods:         *resource.NewQuantity(p.Pods, resource.DecimalSI),
+				corev1.ResourcePods:           *resource.NewQuantity(p.Pods, resource.DecimalSI),
 			},
 		},
 	}

--- a/pkg/k8s/quota_test.go
+++ b/pkg/k8s/quota_test.go
@@ -23,17 +23,17 @@ func TestCreateResourceQuota_SmallPreset(t *testing.T) {
 		t.Fatalf("Get ResourceQuota: %v", err)
 	}
 
-	cpuLimit := quota.Spec.Hard[corev1.ResourceLimitsCPU]
-	if cpuLimit.String() != "2" {
-		t.Errorf("small CPU limit: expected '2', got %q", cpuLimit.String())
+	cpuReq := quota.Spec.Hard[corev1.ResourceRequestsCPU]
+	if cpuReq.String() != "4" {
+		t.Errorf("small CPU request quota: expected '4', got %q", cpuReq.String())
 	}
-	memLimit := quota.Spec.Hard[corev1.ResourceLimitsMemory]
-	if memLimit.String() != "2Gi" {
-		t.Errorf("small memory limit: expected '2Gi', got %q", memLimit.String())
+	memReq := quota.Spec.Hard[corev1.ResourceRequestsMemory]
+	if memReq.String() != "4Gi" {
+		t.Errorf("small memory request quota: expected '4Gi', got %q", memReq.String())
 	}
 	pods := quota.Spec.Hard[corev1.ResourcePods]
-	if pods.Value() != 10 {
-		t.Errorf("small pod limit: expected 10, got %d", pods.Value())
+	if pods.Value() != 20 {
+		t.Errorf("small pod limit: expected 20, got %d", pods.Value())
 	}
 }
 
@@ -47,13 +47,13 @@ func TestCreateResourceQuota_MediumPreset(t *testing.T) {
 		t.Fatalf("Get ResourceQuota: %v", err)
 	}
 
-	cpuLimit := quota.Spec.Hard[corev1.ResourceLimitsCPU]
-	if cpuLimit.String() != "4" {
-		t.Errorf("medium CPU limit: expected '4', got %q", cpuLimit.String())
+	cpuReq := quota.Spec.Hard[corev1.ResourceRequestsCPU]
+	if cpuReq.String() != "16" {
+		t.Errorf("medium CPU request quota: expected '16', got %q", cpuReq.String())
 	}
-	memLimit := quota.Spec.Hard[corev1.ResourceLimitsMemory]
-	if memLimit.String() != "8Gi" {
-		t.Errorf("medium memory limit: expected '8Gi', got %q", memLimit.String())
+	memReq := quota.Spec.Hard[corev1.ResourceRequestsMemory]
+	if memReq.String() != "16Gi" {
+		t.Errorf("medium memory request quota: expected '16Gi', got %q", memReq.String())
 	}
 }
 
@@ -67,13 +67,13 @@ func TestCreateResourceQuota_LargePreset(t *testing.T) {
 		t.Fatalf("Get ResourceQuota: %v", err)
 	}
 
-	cpuLimit := quota.Spec.Hard[corev1.ResourceLimitsCPU]
-	if cpuLimit.String() != "8" {
-		t.Errorf("large CPU limit: expected '8', got %q", cpuLimit.String())
+	cpuReq := quota.Spec.Hard[corev1.ResourceRequestsCPU]
+	if cpuReq.String() != "32" {
+		t.Errorf("large CPU request quota: expected '32', got %q", cpuReq.String())
 	}
 	pods := quota.Spec.Hard[corev1.ResourcePods]
-	if pods.Value() != 50 {
-		t.Errorf("large pod limit: expected 50, got %d", pods.Value())
+	if pods.Value() != 100 {
+		t.Errorf("large pod limit: expected 100, got %d", pods.Value())
 	}
 }
 
@@ -119,8 +119,8 @@ func TestCreateLimitRange_DefaultsSet(t *testing.T) {
 	}
 
 	cpuReq := item.DefaultRequest[corev1.ResourceCPU]
-	if cpuReq.String() != "100m" {
-		t.Errorf("default CPU request: expected '100m', got %q", cpuReq.String())
+	if cpuReq.String() != "50m" {
+		t.Errorf("default CPU request: expected '50m', got %q", cpuReq.String())
 	}
 	memReq := item.DefaultRequest[corev1.ResourceMemory]
 	if memReq.String() != "64Mi" {

--- a/pkg/tools/enclave.go
+++ b/pkg/tools/enclave.go
@@ -115,6 +115,7 @@ type EnclaveSyncParams struct {
 	NewChannelName string   `json:"new_channel_name,omitempty" jsonschema:"Update the platform channel name"`
 	NewStatus      string   `json:"new_status,omitempty" jsonschema:"Update enclave lifecycle status: active or frozen"`
 	NewMode        string   `json:"new_mode,omitempty" jsonschema:"Set the default permission mode for new tentacles in this enclave (9-char rwx string, e.g. rwxrwx---)"`
+	NewQuotaPreset string   `json:"new_quota_preset,omitempty" jsonschema:"Update resource quota preset: small, medium, or large"`
 	AddMembers     []string `json:"add_members,omitempty" jsonschema:"Email addresses of members to add (CSV format)"`
 	RemoveMembers  []string `json:"remove_members,omitempty" jsonschema:"Email addresses of members to remove (CSV format)"`
 }
@@ -228,7 +229,7 @@ func registerEnclaveTools(srv *mcp.Server, client *k8s.Client, exoCtrl *exoskele
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "enclave_sync",
-		Description: "Update an enclave: add/remove members, transfer ownership, update channel name, or change lifecycle status (freeze/unfreeze).",
+		Description: "Update an enclave: add/remove members, transfer ownership, update channel name, change lifecycle status, or update resource quota.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Sync Enclave",
 			ReadOnlyHint:    false,
@@ -593,7 +594,7 @@ func attemptEnclaveSync(ctx context.Context, client *k8s.Client, params EnclaveS
 
 	// Ownership transfer, member management, mode changes, and freeze/unfreeze are owner-only.
 	// Bearer-token callers bypass this check (platform operators).
-	isOwnerOp := params.NewOwner != "" || len(params.AddMembers) > 0 || len(params.RemoveMembers) > 0 || params.NewStatus != "" || params.NewMode != ""
+	isOwnerOp := params.NewOwner != "" || len(params.AddMembers) > 0 || len(params.RemoveMembers) > 0 || params.NewStatus != "" || params.NewMode != "" || params.NewQuotaPreset != ""
 	if isOwnerOp && deployer != nil && deployer.Provider != "bearer-token" {
 		if deployer.Email == "" {
 			return EnclaveSyncResult{}, false, errors.New("permission denied: OIDC caller has no email claim")
@@ -708,8 +709,20 @@ func attemptEnclaveSync(ctx context.Context, client *k8s.Client, params EnclaveS
 		updated = append(updated, "mode")
 	}
 
+	// Handle quota preset change (owner-only, guarded by isOwnerOp above).
+	if params.NewQuotaPreset != "" {
+		if !validQuotaPresets[params.NewQuotaPreset] {
+			return EnclaveSyncResult{}, false, fmt.Errorf("invalid quota_preset %q; valid values: small, medium, large", params.NewQuotaPreset)
+		}
+		if err := k8s.UpdateResourceQuota(ctx, client, params.Name, params.NewQuotaPreset); err != nil {
+			return EnclaveSyncResult{}, false, fmt.Errorf("updating resource quota: %w", err)
+		}
+		ann[annotationEnclaveQuotaPreset] = params.NewQuotaPreset
+		updated = append(updated, "quota_preset")
+	}
+
 	if len(updated) == 0 {
-		return EnclaveSyncResult{}, false, errors.New("no updates specified; provide at least one of add_members, remove_members, new_owner, new_channel_name, new_status, or new_mode")
+		return EnclaveSyncResult{}, false, errors.New("no updates specified; provide at least one of add_members, remove_members, new_owner, new_channel_name, new_status, new_mode, or new_quota_preset")
 	}
 
 	// Write updated annotations.

--- a/pkg/tools/health.go
+++ b/pkg/tools/health.go
@@ -209,10 +209,18 @@ func handleHealthNsUsage(ctx context.Context, client *k8s.Client, params HealthN
 
 	quota := quotaList.Items[0]
 
-	cpuUsed := quota.Status.Used[corev1.ResourceLimitsCPU]
-	cpuLimit := quota.Status.Hard[corev1.ResourceLimitsCPU]
-	memUsed := quota.Status.Used[corev1.ResourceLimitsMemory]
-	memLimit := quota.Status.Hard[corev1.ResourceLimitsMemory]
+	// Try requests-based quota first (new default), fall back to limits-based
+	// for enclaves provisioned before the quota model change.
+	cpuUsed := quota.Status.Used[corev1.ResourceRequestsCPU]
+	cpuLimit := quota.Status.Hard[corev1.ResourceRequestsCPU]
+	memUsed := quota.Status.Used[corev1.ResourceRequestsMemory]
+	memLimit := quota.Status.Hard[corev1.ResourceRequestsMemory]
+	if cpuLimit.IsZero() {
+		cpuUsed = quota.Status.Used[corev1.ResourceLimitsCPU]
+		cpuLimit = quota.Status.Hard[corev1.ResourceLimitsCPU]
+		memUsed = quota.Status.Used[corev1.ResourceLimitsMemory]
+		memLimit = quota.Status.Hard[corev1.ResourceLimitsMemory]
+	}
 	podUsed := quota.Status.Used[corev1.ResourcePods]
 	podLimit := quota.Status.Hard[corev1.ResourcePods]
 

--- a/test/integration/clusterops_test.go
+++ b/test/integration/clusterops_test.go
@@ -68,21 +68,21 @@ func TestIntegration_ClusterProfileWithNamespace(t *testing.T) {
 	if profile.Quota == nil {
 		t.Error("expected Quota to be populated")
 	} else {
-		if profile.Quota.CPULimit != "4" {
-			t.Errorf("expected quota CPU limit 4, got %s", profile.Quota.CPULimit)
+		if profile.Quota.CPURequest != "16" {
+			t.Errorf("expected quota CPU request 16, got %s", profile.Quota.CPURequest)
 		}
-		if profile.Quota.MemoryLimit != "8Gi" {
-			t.Errorf("expected quota mem limit 8Gi, got %s", profile.Quota.MemoryLimit)
+		if profile.Quota.MemoryRequest != "16Gi" {
+			t.Errorf("expected quota memory request 16Gi, got %s", profile.Quota.MemoryRequest)
 		}
-		if profile.Quota.MaxPods != 20 {
-			t.Errorf("expected quota pod limit 20, got %d", profile.Quota.MaxPods)
+		if profile.Quota.MaxPods != 50 {
+			t.Errorf("expected quota pod limit 50, got %d", profile.Quota.MaxPods)
 		}
 	}
 	if profile.LimitRange == nil {
 		t.Error("expected LimitRange to be populated")
 	} else {
-		if profile.LimitRange.DefaultCPURequest != "100m" {
-			t.Errorf("expected default CPU request 100m, got %s", profile.LimitRange.DefaultCPURequest)
+		if profile.LimitRange.DefaultCPURequest != "50m" {
+			t.Errorf("expected default CPU request 50m, got %s", profile.LimitRange.DefaultCPURequest)
 		}
 	}
 	if profile.PodSecurity != "restricted" {

--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -243,7 +243,7 @@ func TestE2E_ClusterPreflightAndProfile(t *testing.T) {
 		} `json:"cni"`
 		Namespace string `json:"namespace"`
 		Quota     *struct {
-			CPULimit string `json:"cpuLimit"`
+			CPURequest string `json:"cpuRequest"`
 		} `json:"quota"`
 	}
 	if err := json.Unmarshal([]byte(text), &profileResult); err != nil {
@@ -261,8 +261,8 @@ func TestE2E_ClusterPreflightAndProfile(t *testing.T) {
 	if profileResult.Namespace != nsName {
 		t.Errorf("cluster_profile namespace: got %q, want %q", profileResult.Namespace, nsName)
 	}
-	if profileResult.Quota == nil || profileResult.Quota.CPULimit != "4" {
-		t.Error("cluster_profile: expected quota with CPU=4")
+	if profileResult.Quota == nil || profileResult.Quota.CPURequest != "16" {
+		t.Error("cluster_profile: expected quota with cpuRequest=16")
 	}
 	t.Logf("cluster_profile: K8s=%s dist=%s CNI=%s nodes=%d",
 		profileResult.K8sVersion, profileResult.Distribution,

--- a/test/integration/health_test.go
+++ b/test/integration/health_test.go
@@ -94,14 +94,14 @@ func TestIntegration_HealthNsUsageWithQuota(t *testing.T) {
 	}
 
 	q := quotas.Items[0]
-	if cpu := q.Spec.Hard[corev1.ResourceLimitsCPU]; cpu.String() != "4" {
-		t.Errorf("expected CPU limit 4, got %s", cpu.String())
+	if cpu := q.Spec.Hard[corev1.ResourceRequestsCPU]; cpu.String() != "16" {
+		t.Errorf("expected CPU request 16, got %s", cpu.String())
 	}
-	if mem := q.Spec.Hard[corev1.ResourceLimitsMemory]; mem.String() != "8Gi" {
-		t.Errorf("expected memory limit 8Gi, got %s", mem.String())
+	if mem := q.Spec.Hard[corev1.ResourceRequestsMemory]; mem.String() != "16Gi" {
+		t.Errorf("expected memory request 16Gi, got %s", mem.String())
 	}
-	if pods := q.Spec.Hard[corev1.ResourcePods]; pods.String() != "20" {
-		t.Errorf("expected pod limit 20, got %s", pods.String())
+	if pods := q.Spec.Hard[corev1.ResourcePods]; pods.String() != "50" {
+		t.Errorf("expected pod limit 50, got %s", pods.String())
 	}
 }
 

--- a/test/integration/namespace_test.go
+++ b/test/integration/namespace_test.go
@@ -108,11 +108,11 @@ func TestIntegration_NamespaceGetDetails(t *testing.T) {
 		t.Fatalf("expected 1 quota, got %d", len(quotas.Items))
 	}
 	q := quotas.Items[0]
-	if cpu := q.Spec.Hard["limits.cpu"]; cpu.String() != "4" {
-		t.Errorf("expected CPU limit 4, got %s", cpu.String())
+	if cpu := q.Spec.Hard["requests.cpu"]; cpu.String() != "4" {
+		t.Errorf("expected CPU request quota 4, got %s", cpu.String())
 	}
-	if mem := q.Spec.Hard["limits.memory"]; mem.String() != "8Gi" {
-		t.Errorf("expected memory limit 8Gi, got %s", mem.String())
+	if mem := q.Spec.Hard["requests.memory"]; mem.String() != "4Gi" {
+		t.Errorf("expected memory request quota 4Gi, got %s", mem.String())
 	}
 	if pods := q.Spec.Hard["pods"]; pods.String() != "20" {
 		t.Errorf("expected pod limit 20, got %s", pods.String())

--- a/test/integration/namespace_test.go
+++ b/test/integration/namespace_test.go
@@ -108,14 +108,14 @@ func TestIntegration_NamespaceGetDetails(t *testing.T) {
 		t.Fatalf("expected 1 quota, got %d", len(quotas.Items))
 	}
 	q := quotas.Items[0]
-	if cpu := q.Spec.Hard["requests.cpu"]; cpu.String() != "4" {
-		t.Errorf("expected CPU request quota 4, got %s", cpu.String())
+	if cpu := q.Spec.Hard["requests.cpu"]; cpu.String() != "16" {
+		t.Errorf("expected CPU request quota 16, got %s", cpu.String())
 	}
-	if mem := q.Spec.Hard["requests.memory"]; mem.String() != "4Gi" {
-		t.Errorf("expected memory request quota 4Gi, got %s", mem.String())
+	if mem := q.Spec.Hard["requests.memory"]; mem.String() != "16Gi" {
+		t.Errorf("expected memory request quota 16Gi, got %s", mem.String())
 	}
-	if pods := q.Spec.Hard["pods"]; pods.String() != "20" {
-		t.Errorf("expected pod limit 20, got %s", pods.String())
+	if pods := q.Spec.Hard["pods"]; pods.String() != "50" {
+		t.Errorf("expected pod limit 50, got %s", pods.String())
 	}
 
 	lrs, err := cs.CoreV1().LimitRanges(nsName).List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
## Summary
- Switch ResourceQuota from `limits.cpu`/`limits.memory` to `requests.cpu`/`requests.memory` to support bursty tentacle workloads
- Raise presets: small 4/4Gi/20, medium 16/16Gi/50, large 32/64Gi/100
- Lower LimitRange default CPU request from 100m to 50m (idle tentacles)
- Add `new_quota_preset` parameter to `enclave_sync` tool
- `health_ns_usage` gracefully falls back to limits-based for pre-existing enclaves

## Test plan
- [x] All unit tests pass (`go test ./pkg/...`)
- [x] Integration tests compile
- [ ] Deploy to eastus, verify `enclave_sync` with `new_quota_preset` updates quota
- [ ] Verify `health_ns_usage` reports correct values for both old and new enclaves

See also randybias/tentacular#122

🤖 Generated with [Claude Code](https://claude.com/claude-code)