### PR TITLE
feat: add platform_config MCP tool

### DIFF
--- a/charts/tentacular-mcp/templates/deployment.yaml
+++ b/charts/tentacular-mcp/templates/deployment.yaml
@@ -62,6 +62,14 @@ spec:
             - name: TENTACULAR_EXTERNAL_URL
               value: {{ .Values.externalURL | quote }}
             {{- end }}
+            {{- if .Values.platform.chromaUrl }}
+            - name: TENTACULAR_CHROMA_URL
+              value: {{ .Values.platform.chromaUrl | quote }}
+            {{- end }}
+            {{- if .Values.platform.docsUrl }}
+            - name: TENTACULAR_DOCS_URL
+              value: {{ .Values.platform.docsUrl | quote }}
+            {{- end }}
             {{- if not .Values.authz.enabled }}
             - name: TENTACULAR_AUTHZ_ENABLED
               value: "false"

--- a/charts/tentacular-mcp/values.yaml
+++ b/charts/tentacular-mcp/values.yaml
@@ -195,3 +195,10 @@ exoskeleton:
     secretKey: ""
     bucket: "tentacular"
     region: "us-east-1"
+
+# -- Platform service URLs for cross-service discovery.
+platform:
+  # -- Chroma enclave UI URL (e.g., "https://chroma.example.com")
+  chromaUrl: ""
+  # -- Documentation site URL (e.g., "https://docs.example.com")
+  docsUrl: ""

--- a/pkg/tools/platform.go
+++ b/pkg/tools/platform.go
@@ -1,0 +1,37 @@
+package tools
+
+import (
+	"context"
+	"os"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// PlatformConfigParams are the parameters for platform_config (none required).
+type PlatformConfigParams struct{}
+
+// PlatformConfigResult is the result of platform_config.
+type PlatformConfigResult struct {
+	ChromaURL string `json:"chroma_url"`
+	DocsURL   string `json:"docs_url"`
+}
+
+func registerPlatformTools(srv *mcp.Server) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "platform_config",
+		Description: "Returns platform service URLs for integration (Chroma UI, documentation site).",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Get Platform Configuration",
+			ReadOnlyHint:    true,
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(false),
+		},
+	}, func(ctx context.Context, req *mcp.CallToolRequest, params PlatformConfigParams) (*mcp.CallToolResult, PlatformConfigResult, error) {
+		result := PlatformConfigResult{
+			ChromaURL: os.Getenv("TENTACULAR_CHROMA_URL"),
+			DocsURL:   os.Getenv("TENTACULAR_DOCS_URL"),
+		}
+		return nil, result, nil
+	})
+}

--- a/pkg/tools/register.go
+++ b/pkg/tools/register.go
@@ -26,4 +26,5 @@ func RegisterAll(srv *mcp.Server, client *k8s.Client, reconciler *proxy.Reconcil
 	registerAuditTools(srv, client, eval)
 	registerProxyTools(srv, reconciler)
 	registerEnclaveTools(srv, client, exoCtrl, eval)
+	registerPlatformTools(srv)
 }


### PR DESCRIPTION
## Summary
- New `platform_config` read-only MCP tool returning Chroma UI and docs site URLs
- URLs configured via Helm values (`platform.chromaUrl`, `platform.docsUrl`) mapped to env vars
- Enables Kraken Slack bot to discover Chroma URL for "View in Chroma" deep link buttons

Part of the observability meta-plan (MCP Discovery + Deep Links). See also randybias/thekraken#7 and randybias/tentacular-chroma#5.

## Test plan
- [ ] `go build ./...` passes
- [ ] `golangci-lint run ./...` passes
- [ ] Deploy with `platform.chromaUrl` set in values
- [ ] Call `platform_config` via tntc — verify URLs returned
- [ ] Call with no values set — verify empty strings (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)