### PR TITLE
fix: correct Keycloak OIDC client configuration

### DIFF
--- a/charts/tentacular-platform/templates/keycloak-realm-configmap.yaml
+++ b/charts/tentacular-platform/templates/keycloak-realm-configmap.yaml
@@ -1,19 +1,34 @@
 {{/*
 Keycloak realm import ConfigMap.
-Contains the tentacular realm definition with the tentacular-mcp OIDC client.
+Contains the tentacular realm definition with all OIDC clients.
 Mounted into the Keycloak pod at /opt/keycloak/data/import/ and imported
-on startup via the --import-realm flag.
+on first startup via the --import-realm flag (skips if realm already exists).
+
+IMPORTANT: Keycloak only imports this on FIRST startup when the realm does not
+exist in the database. After that, the Postgres database is authoritative.
+Changes here only take effect on a fresh Keycloak database or if the realm is
+deleted and re-imported.
+
+Client configuration:
+  tentacular-mcp  - PUBLIC client for tntc CLI + Claude Code OAuth (no secret)
+                    Flows: authorization code + PKCE, device authorization, direct access
+                    The MCP server itself is a resource server (validates tokens),
+                    not an OIDC client. This client is used by MCP consumers.
+  thekraken       - CONFIDENTIAL client for the Slack bot
+                    Flows: client_credentials (bot-level MCP calls), device auth,
+                    direct access grants
+  chroma          - CONFIDENTIAL client for the Next.js enclave UI
+                    Flows: authorization code (NextAuth server-side)
 */}}
 {{- if .Values.keycloak.enabled }}
-{{- $kcHost := .Values.keycloak.hostname | default (printf "tentacular-keycloak.%s" .Values.global.domain) }}
+{{- $kcScheme := ternary "https" "http" .Values.ingress.tls.enabled }}
+{{- $realm := .Values.keycloak.realm | default "tentacular" }}
 {{- $mcpHost := "" }}
 {{- if and .Values.ingress .Values.ingress.mcp }}
 {{- $mcpHost = .Values.ingress.mcp.hostname }}
 {{- end }}
 {{- $mcpHost = $mcpHost | default (printf "tentacular-mcp.%s" .Values.global.domain) }}
-{{- $kcScheme := ternary "https" "http" .Values.ingress.tls.enabled }}
-{{- $realm := .Values.keycloak.realm | default "tentacular" }}
-{{- $clientID := .Values.exoskeletonAuth.clientID | default "tentacular-mcp" }}
+{{- $chromaHost := .Values.keycloak.clients.chroma.hostname | default (printf "chroma.%s" .Values.global.domain) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -37,13 +52,35 @@ data:
       "offlineSessionIdleTimeout": 2592000,
       "clients": [
         {
-          "clientId": {{ $clientID | quote }},
+          "clientId": {{ .Values.keycloak.clients.mcp.clientId | default "tentacular-mcp" | quote }},
           "name": "Tentacular MCP Server",
           "enabled": true,
           "protocol": "openid-connect",
-          "publicClient": false,
-          "secret": {{ .Values.exoskeletonAuth.clientSecret | default "" | quote }},
+          "publicClient": true,
           "standardFlowEnabled": true,
+          "directAccessGrantsEnabled": true,
+          "serviceAccountsEnabled": false,
+          "authorizationServicesEnabled": false,
+          "attributes": {
+            "oauth2.device.authorization.grant.enabled": "true",
+            "oauth2.device.polling.interval": "5"
+          },
+          "redirectUris": [
+            "http://localhost:*",
+            "{{ $kcScheme }}://{{ $mcpHost }}/*"
+          ],
+          "webOrigins": ["+"],
+          "defaultClientScopes": ["openid", "email", "profile"]
+        },
+        {
+          "clientId": {{ .Values.keycloak.clients.kraken.clientId | default "thekraken" | quote }},
+          "name": "The Kraken (Slack Bot)",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "clientAuthenticatorType": "client-secret",
+          "secret": {{ .Values.keycloak.clients.kraken.clientSecret | default "" | quote }},
+          "publicClient": false,
+          "standardFlowEnabled": false,
           "directAccessGrantsEnabled": true,
           "serviceAccountsEnabled": true,
           "authorizationServicesEnabled": false,
@@ -51,8 +88,25 @@ data:
             "oauth2.device.authorization.grant.enabled": "true",
             "oauth2.device.polling.interval": "5"
           },
+          "redirectUris": ["*"],
+          "webOrigins": ["+"],
+          "defaultClientScopes": ["openid", "email", "profile"]
+        },
+        {
+          "clientId": {{ .Values.keycloak.clients.chroma.clientId | default "chroma" | quote }},
+          "name": "Chroma (Enclave UI)",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "clientAuthenticatorType": "client-secret",
+          "secret": {{ .Values.keycloak.clients.chroma.clientSecret | default "" | quote }},
+          "publicClient": false,
+          "standardFlowEnabled": true,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "authorizationServicesEnabled": false,
           "redirectUris": [
-            "{{ $kcScheme }}://{{ $mcpHost }}/*"
+            "{{ $kcScheme }}://{{ $chromaHost }}/*",
+            "http://localhost:3000/*"
           ],
           "webOrigins": ["+"],
           "defaultClientScopes": ["openid", "email", "profile"]

--- a/charts/tentacular-platform/values.yaml
+++ b/charts/tentacular-platform/values.yaml
@@ -319,6 +319,29 @@ keycloak:
   ingress:
     # -- Enable Keycloak Ingress (uses the same className as platform ingress)
     enabled: true
+  # -- OIDC client configuration for all platform services.
+  # See templates/keycloak-realm-configmap.yaml for how these map to the realm.
+  clients:
+    # -- MCP server consumer client (PUBLIC).
+    # Used by tntc CLI (device auth) and Claude Code (.mcp.json OAuth).
+    # The MCP server itself is a resource server — it validates tokens,
+    # it does not authenticate to Keycloak. This client exists for its consumers.
+    mcp:
+      clientId: "tentacular-mcp"
+    # -- The Kraken Slack bot client (CONFIDENTIAL).
+    # Uses client_credentials for bot-level MCP calls and device auth
+    # for per-user transitive trust.
+    kraken:
+      clientId: "thekraken"
+      clientSecret: ""
+      # -- Hostname not needed — Kraken uses direct access grants, not redirects
+    # -- Chroma enclave UI client (CONFIDENTIAL).
+    # Uses authorization code flow via NextAuth server-side.
+    chroma:
+      clientId: "chroma"
+      clientSecret: ""
+      # -- Chroma hostname for redirect URIs
+      hostname: ""
 
 # -- keycloakx subchart configuration (passed through to codecentric/keycloakx)
 # See https://github.com/codecentric/helm-charts/tree/master/charts/keycloakx

--- a/docs/keycloak-oidc-clients.md
+++ b/docs/keycloak-oidc-clients.md
@@ -1,0 +1,128 @@
+# Keycloak OIDC Client Configuration
+
+The Tentacular platform uses Keycloak as its identity provider. Three OIDC clients serve different platform consumers.
+
+## Architecture
+
+```
+                  Keycloak (tentacular realm)
+                    |         |          |
+         tentacular-mcp   thekraken    chroma
+          (PUBLIC)       (CONFIDENTIAL) (CONFIDENTIAL)
+            |                |              |
+     +------+------+        |              |
+     |             |         |              |
+  tntc CLI    Claude Code  Slack Bot    Next.js UI
+  (device)    (.mcp.json)  (client_creds) (auth code)
+     |             |         |              |
+     +------+------+---------+--------------+
+                    |
+              MCP Server
+           (resource server -
+            validates tokens)
+```
+
+The MCP server is a **resource server**, not an OIDC client. It validates tokens issued to any of the above clients by checking the JWT signature against Keycloak's JWKS endpoint and the `azp` (authorized party) claim. The MCP server's `TENTACULAR_KEYCLOAK_TRUSTED_AZPS` env var lists which client IDs it trusts (currently: `thekraken,chroma`; `tentacular-mcp` is implicitly trusted as the primary client).
+
+## Clients
+
+### tentacular-mcp (PUBLIC)
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| publicClient | **true** | Consumers (tntc CLI, Claude Code) cannot hold secrets |
+| serviceAccountsEnabled | false | No machine-to-machine auth needed through this client |
+| standardFlowEnabled | true | Claude Code uses authorization code + PKCE |
+| directAccessGrantsEnabled | true | tntc CLI can use resource owner password grant |
+| deviceAuth | true | tntc CLI primary flow (device authorization) |
+
+**Consumers:**
+- `tntc` CLI: Device authorization flow (`tntc login` opens browser, polls for token)
+- Claude Code `.mcp.json`: Authorization code + PKCE via OAuth popup (no client secret in config)
+
+**Why public:** Both consumers run on a developer's machine. A CLI binary and a browser-based OAuth popup cannot securely store a client secret. PKCE provides equivalent security for public clients.
+
+### thekraken (CONFIDENTIAL)
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| publicClient | false | Server-side Slack bot can hold a secret |
+| serviceAccountsEnabled | **true** | Bot uses `client_credentials` for bot-level MCP calls |
+| standardFlowEnabled | false | No browser-based login |
+| directAccessGrantsEnabled | true | Used for per-user transitive trust authentication |
+| deviceAuth | true | Per-user OIDC authentication via Slack DM |
+
+**Consumer:** The Kraken Slack bot (Node.js, runs in Kubernetes).
+
+**Why confidential:** The bot runs server-side in a pod with the secret injected via Kubernetes Secret. It uses `client_credentials` grant to get a service token for bot-level MCP calls (no user context), and device authorization for per-user transitive trust.
+
+### chroma (CONFIDENTIAL)
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| publicClient | false | Server-side Next.js can hold a secret |
+| serviceAccountsEnabled | false | All requests are on behalf of a user |
+| standardFlowEnabled | **true** | NextAuth uses authorization code flow |
+| directAccessGrantsEnabled | false | No need for direct access |
+| deviceAuth | false | Browser-only, no device flow needed |
+
+**Consumer:** Chroma enclave UI (Next.js 15, runs in Kubernetes).
+
+**Why confidential:** NextAuth runs server-side in the Next.js API routes. The client secret is injected via Kubernetes Secret. All authentication is authorization code flow with a server-side callback.
+
+## Persistence Model
+
+Keycloak uses **PostgreSQL** for persistent storage. The realm import ConfigMap (`keycloak-realm-configmap.yaml`) is a **seed file only** — Keycloak reads it on first startup via `--import-realm` and skips it if the realm already exists in the database.
+
+**This means:**
+1. The Postgres database is the authoritative source after first boot
+2. Changes made in the Keycloak admin console persist in the DB
+3. The ConfigMap is NOT re-imported on pod restarts (as long as the DB has the realm)
+4. The ConfigMap IS imported if the database is wiped (fresh Keycloak install)
+
+**Keep the ConfigMap in sync with the live state.** If you change a client in the admin console, update the Helm template (`charts/tentacular-platform/templates/keycloak-realm-configmap.yaml`) to match. Otherwise a database wipe will regress to the old ConfigMap values.
+
+## Common Failure Modes
+
+### "Invalid client or Invalid client credentials"
+The client is configured as confidential but the consumer is trying a public flow (no secret). Check `publicClient` on the Keycloak client. For `tentacular-mcp`, this MUST be `true`.
+
+### "Invalid refresh token" / token expiry
+Token lifespans are set at the realm level:
+- Access token: 12 hours (`accessTokenLifespan: 43200`)
+- SSO session idle: 12 hours
+- SSO session max: 24 hours
+- Offline session idle: 30 days
+
+If sessions expire too fast, check these realm settings in Keycloak admin.
+
+### ConfigMap drift
+If the live Keycloak state doesn't match the ConfigMap, the next database wipe will cause a regression. To check for drift:
+
+```bash
+# Compare live vs ConfigMap
+# (use the admin API to query live state, compare against ConfigMap)
+KEYCLOAK_SVC="https://auth.eastus-dev1.ospo-dev.miralabs.dev"
+# ... get admin token ...
+curl -s -H "Authorization: Bearer $TOKEN" "$KEYCLOAK_SVC/admin/realms/tentacular/clients?clientId=tentacular-mcp"
+```
+
+## Helm Values
+
+Client configuration lives in `charts/tentacular-platform/values.yaml` under `keycloak.clients`:
+
+```yaml
+keycloak:
+  clients:
+    mcp:
+      clientId: "tentacular-mcp"       # PUBLIC - no secret needed
+    kraken:
+      clientId: "thekraken"
+      clientSecret: "<from-secret>"    # CONFIDENTIAL
+    chroma:
+      clientId: "chroma"
+      clientSecret: "<from-secret>"    # CONFIDENTIAL
+      hostname: "chroma.example.com"   # For redirect URI generation
+```
+
+Secrets should be provided via `--set` or an existing Kubernetes Secret, never committed to values.yaml.


### PR DESCRIPTION
## Summary

- Fix `tentacular-mcp` client to be **public** (`publicClient: true`, no secret) — tntc CLI and Claude Code cannot hold a client secret
- Add `thekraken` client (confidential, `client_credentials` + device auth for Slack bot)
- Add `chroma` client (confidential, authorization code for NextAuth)
- Add `keycloak.clients` values section for all three clients
- Add comprehensive docs at `docs/keycloak-oidc-clients.md`

The previous ConfigMap had only one client (`tentacular-mcp`) set to confidential, which broke all public PKCE/device auth flows after a fresh Keycloak import.

**Note:** The ConfigMap is a seed file only — Keycloak imports it on first startup and then the Postgres DB is authoritative. The live cluster was already patched via admin API. This PR ensures the Helm chart matches the live state so future DB resets won't regress.

## Test plan

- [ ] `helm template` renders all three clients with correct settings
- [ ] Fresh Keycloak import creates all three clients
- [ ] `tntc login` works (device auth via public client)
- [ ] Claude Code `.mcp.json` OAuth works (PKCE via public client)
- [ ] Kraken `client_credentials` grant works (confidential client)
- [ ] Chroma NextAuth login works (authorization code via confidential client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)