### PR TITLE
feat: add oauth2-proxy auth for SigNoz via Keycloak

### DIFF
--- a/charts/tentacular-observability/templates/networkpolicy.yaml
+++ b/charts/tentacular-observability/templates/networkpolicy.yaml
@@ -77,7 +77,9 @@ spec:
 {{- end }}
 ---
 {{/*
-Allow Traefik ingress controller to reach the SigNoz frontend pod.
+Allow traffic to reach the SigNoz frontend pod.
+Sources: Traefik (direct, when oauth2-proxy disabled) and oauth2-proxy
+(reverse-proxy upstream, when oauth2-proxy enabled).
 */}}
 {{- if and .Values.networkPolicy.create .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
@@ -96,6 +98,18 @@ spec:
   policyTypes:
     - Ingress
   ingress:
+    {{- if .Values.oauth2Proxy.enabled }}
+    # oauth2-proxy reverse-proxies authenticated requests to SigNoz
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: oauth2-proxy
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- else }}
+    # Direct ingress from Traefik when no auth proxy is in use
     - from:
         - namespaceSelector:
             matchLabels:
@@ -103,6 +117,7 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+    {{- end }}
 {{- end }}
 ---
 {{/*
@@ -144,6 +159,15 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: tentacular-exoskeleton
+      ports:
+        - protocol: TCP
+          port: 8080
+    # SigNoz upstream (reverse-proxy mode, same namespace)
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: signoz
+              app.kubernetes.io/component: signoz
       ports:
         - protocol: TCP
           port: 8080

--- a/charts/tentacular-observability/templates/networkpolicy.yaml
+++ b/charts/tentacular-observability/templates/networkpolicy.yaml
@@ -46,3 +46,105 @@ spec:
         - protocol: TCP
           port: 4318
 {{- end }}
+---
+{{/*
+Allow Traefik ingress controller to reach the oauth2-proxy pod (forwardAuth).
+*/}}
+{{- if and .Values.networkPolicy.create .Values.oauth2Proxy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "tentacular-observability.fullname" . }}-oauth2-proxy-ingress
+  namespace: {{ include "tentacular-observability.namespace" . }}
+  labels:
+    {{- include "tentacular-observability.labels" . | nindent 4 }}
+    app.kubernetes.io/component: oauth2-proxy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+      ports:
+        - protocol: TCP
+          port: 4180
+{{- end }}
+---
+{{/*
+Allow Traefik ingress controller to reach the SigNoz frontend pod.
+*/}}
+{{- if and .Values.networkPolicy.create .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "tentacular-observability.fullname" . }}-signoz-ingress
+  namespace: {{ include "tentacular-observability.namespace" . }}
+  labels:
+    {{- include "tentacular-observability.labels" . | nindent 4 }}
+    app.kubernetes.io/component: signoz
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: signoz
+      app.kubernetes.io/component: signoz
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+      ports:
+        - protocol: TCP
+          port: 8080
+{{- end }}
+---
+{{/*
+Allow oauth2-proxy egress to Keycloak (HTTPS) and DNS.
+*/}}
+{{- if and .Values.networkPolicy.create .Values.oauth2Proxy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "tentacular-observability.fullname" . }}-oauth2-proxy-egress
+  namespace: {{ include "tentacular-observability.namespace" . }}
+  labels:
+    {{- include "tentacular-observability.labels" . | nindent 4 }}
+    app.kubernetes.io/component: oauth2-proxy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+  egress:
+    # DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Keycloak OIDC endpoints (HTTPS, via Traefik ingress or in-cluster)
+    - ports:
+        - protocol: TCP
+          port: 443
+    # Keycloak in-cluster (port 8080 in tentacular-exoskeleton)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tentacular-exoskeleton
+      ports:
+        - protocol: TCP
+          port: 8080
+{{- end }}

--- a/charts/tentacular-observability/templates/oauth2-proxy-deployment.yaml
+++ b/charts/tentacular-observability/templates/oauth2-proxy-deployment.yaml
@@ -36,9 +36,8 @@ spec:
             {{- end }}
             - --cookie-secure=true
             - --cookie-samesite=lax
-            - --upstream=static://202
+            - --upstream=http://signoz.{{ include "tentacular-observability.namespace" . }}.svc.cluster.local:8080
             - --reverse-proxy=true
-            - --set-xauthrequest=true
             - --skip-provider-button=true
             - --http-address=0.0.0.0:4180
             - --scope=openid email profile groups

--- a/charts/tentacular-observability/templates/oauth2-proxy-deployment.yaml
+++ b/charts/tentacular-observability/templates/oauth2-proxy-deployment.yaml
@@ -1,0 +1,93 @@
+{{- if .Values.oauth2Proxy.enabled }}
+{{- $secretName := .Values.oauth2Proxy.existingSecret | default (printf "%s-oauth2-proxy" (include "tentacular-observability.fullname" .)) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tentacular-observability.fullname" . }}-oauth2-proxy
+  namespace: {{ include "tentacular-observability.namespace" . }}
+  labels:
+    {{- include "tentacular-observability.labels" . | nindent 4 }}
+    app.kubernetes.io/component: oauth2-proxy
+spec:
+  replicas: {{ .Values.oauth2Proxy.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: oauth2-proxy
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: oauth2-proxy
+    spec:
+      containers:
+        - name: oauth2-proxy
+          image: "{{ .Values.oauth2Proxy.image.repository }}:{{ .Values.oauth2Proxy.image.tag }}"
+          imagePullPolicy: {{ .Values.oauth2Proxy.image.pullPolicy }}
+          args:
+            - --provider=keycloak-oidc
+            - --oidc-issuer-url={{ .Values.oauth2Proxy.issuerURL }}
+            - --client-id=$(CLIENT_ID)
+            - --client-secret=$(CLIENT_SECRET)
+            - --cookie-secret=$(COOKIE_SECRET)
+            {{- if .Values.oauth2Proxy.cookieDomain }}
+            - --cookie-domain={{ .Values.oauth2Proxy.cookieDomain }}
+            {{- end }}
+            - --cookie-secure=true
+            - --cookie-samesite=lax
+            - --upstream=static://202
+            - --reverse-proxy=true
+            - --set-xauthrequest=true
+            - --skip-provider-button=true
+            - --http-address=0.0.0.0:4180
+            - --scope=openid email profile groups
+            {{- if .Values.oauth2Proxy.allowedGroup }}
+            - --allowed-group={{ .Values.oauth2Proxy.allowedGroup }}
+            {{- end }}
+            {{- range .Values.oauth2Proxy.emailDomains }}
+            - --email-domain={{ . }}
+            {{- end }}
+            - --redirect-url={{ ternary "https" "http" .Values.ingress.tls.enabled }}://{{ .Values.ingress.hostname }}/oauth2/callback
+          env:
+            - name: CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: client-id
+            - name: CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: client-secret
+            - name: COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: cookie-secret
+          ports:
+            - name: http
+              containerPort: 4180
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.oauth2Proxy.resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+{{- end }}

--- a/charts/tentacular-observability/templates/oauth2-proxy-ingress.yaml
+++ b/charts/tentacular-observability/templates/oauth2-proxy-ingress.yaml
@@ -1,44 +1,11 @@
 {{/*
-Separate Ingress for the oauth2-proxy callback and sign-in paths.
-This MUST NOT have the forwardAuth middleware annotation — otherwise
-the auth callback would loop through forwardAuth endlessly.
+Separate Ingress for oauth2-proxy callback paths.
+
+NOTE: This is NOT currently needed. When oauth2-proxy acts as a reverse
+proxy (--upstream=http://signoz:8080), all traffic including /oauth2/*
+callback paths goes through the main SigNoz ingress to oauth2-proxy.
+
+This file is retained for future use if the architecture switches to
+Traefik forwardAuth mode, where the /oauth2/* paths must be routed
+separately to avoid middleware loops.
 */}}
-{{- if and .Values.ingress.enabled .Values.oauth2Proxy.enabled }}
-{{- $annotations := dict }}
-{{- if and .Values.ingress.tls.enabled .Values.ingress.tls.clusterIssuer }}
-{{- $_ := set $annotations "cert-manager.io/cluster-issuer" .Values.ingress.tls.clusterIssuer }}
-{{- end }}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: signoz-oauth2-proxy
-  namespace: {{ include "tentacular-observability.namespace" . }}
-  labels:
-    {{- include "tentacular-observability.labels" . | nindent 4 }}
-    app.kubernetes.io/component: oauth2-proxy
-  {{- if $annotations }}
-  annotations:
-    {{- toYaml $annotations | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className | quote }}
-  {{- end }}
-  {{- if .Values.ingress.tls.enabled }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.hostname | quote }}
-      secretName: {{ .Values.ingress.tls.secretName | default "signoz-tls" | quote }}
-  {{- end }}
-  rules:
-    - host: {{ .Values.ingress.hostname | quote }}
-      http:
-        paths:
-          - path: /oauth2
-            pathType: Prefix
-            backend:
-              service:
-                name: oauth2-proxy
-                port:
-                  number: 4180
-{{- end }}

--- a/charts/tentacular-observability/templates/oauth2-proxy-ingress.yaml
+++ b/charts/tentacular-observability/templates/oauth2-proxy-ingress.yaml
@@ -1,0 +1,44 @@
+{{/*
+Separate Ingress for the oauth2-proxy callback and sign-in paths.
+This MUST NOT have the forwardAuth middleware annotation — otherwise
+the auth callback would loop through forwardAuth endlessly.
+*/}}
+{{- if and .Values.ingress.enabled .Values.oauth2Proxy.enabled }}
+{{- $annotations := dict }}
+{{- if and .Values.ingress.tls.enabled .Values.ingress.tls.clusterIssuer }}
+{{- $_ := set $annotations "cert-manager.io/cluster-issuer" .Values.ingress.tls.clusterIssuer }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: signoz-oauth2-proxy
+  namespace: {{ include "tentacular-observability.namespace" . }}
+  labels:
+    {{- include "tentacular-observability.labels" . | nindent 4 }}
+    app.kubernetes.io/component: oauth2-proxy
+  {{- if $annotations }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.hostname | quote }}
+      secretName: {{ .Values.ingress.tls.secretName | default "signoz-tls" | quote }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.hostname | quote }}
+      http:
+        paths:
+          - path: /oauth2
+            pathType: Prefix
+            backend:
+              service:
+                name: oauth2-proxy
+                port:
+                  number: 4180
+{{- end }}

--- a/charts/tentacular-observability/templates/oauth2-proxy-secret.yaml
+++ b/charts/tentacular-observability/templates/oauth2-proxy-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.oauth2Proxy.enabled (not .Values.oauth2Proxy.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tentacular-observability.fullname" . }}-oauth2-proxy
+  namespace: {{ include "tentacular-observability.namespace" . }}
+  labels:
+    {{- include "tentacular-observability.labels" . | nindent 4 }}
+    app.kubernetes.io/component: oauth2-proxy
+type: Opaque
+data:
+  client-id: {{ .Values.oauth2Proxy.clientID | b64enc | quote }}
+  client-secret: {{ .Values.oauth2Proxy.clientSecret | b64enc | quote }}
+  cookie-secret: {{ .Values.oauth2Proxy.cookieSecret | b64enc | quote }}
+{{- end }}

--- a/charts/tentacular-observability/templates/oauth2-proxy-service.yaml
+++ b/charts/tentacular-observability/templates/oauth2-proxy-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.oauth2Proxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: oauth2-proxy
+  namespace: {{ include "tentacular-observability.namespace" . }}
+  labels:
+    {{- include "tentacular-observability.labels" . | nindent 4 }}
+    app.kubernetes.io/component: oauth2-proxy
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: 4180
+      targetPort: 4180
+      protocol: TCP
+{{- end }}

--- a/charts/tentacular-observability/templates/signoz-ingress.yaml
+++ b/charts/tentacular-observability/templates/signoz-ingress.yaml
@@ -1,10 +1,13 @@
+{{/*
+SigNoz Ingress.
+When oauth2-proxy is enabled, the backend points to oauth2-proxy (which
+reverse-proxies to SigNoz after authentication). Without oauth2-proxy,
+the backend points directly to the SigNoz service.
+*/}}
 {{- if .Values.ingress.enabled }}
 {{- $annotations := .Values.ingress.annotations | default dict }}
 {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.clusterIssuer }}
 {{- $_ := set $annotations "cert-manager.io/cluster-issuer" .Values.ingress.tls.clusterIssuer }}
-{{- end }}
-{{- if .Values.oauth2Proxy.enabled }}
-{{- $_ := set $annotations "traefik.ingress.kubernetes.io/router.middlewares" (printf "%s-signoz-forward-auth@kubernetescrd" (include "tentacular-observability.namespace" .)) }}
 {{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -36,7 +39,13 @@ spec:
             pathType: Prefix
             backend:
               service:
+                {{- if .Values.oauth2Proxy.enabled }}
+                name: oauth2-proxy
+                port:
+                  number: 4180
+                {{- else }}
                 name: signoz
                 port:
                   number: 8080
+                {{- end }}
 {{- end }}

--- a/charts/tentacular-observability/templates/signoz-ingress.yaml
+++ b/charts/tentacular-observability/templates/signoz-ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled }}
+{{- $annotations := .Values.ingress.annotations | default dict }}
+{{- if and .Values.ingress.tls.enabled .Values.ingress.tls.clusterIssuer }}
+{{- $_ := set $annotations "cert-manager.io/cluster-issuer" .Values.ingress.tls.clusterIssuer }}
+{{- end }}
+{{- if .Values.oauth2Proxy.enabled }}
+{{- $_ := set $annotations "traefik.ingress.kubernetes.io/router.middlewares" (printf "%s-signoz-forward-auth@kubernetescrd" (include "tentacular-observability.namespace" .)) }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: signoz
+  namespace: {{ include "tentacular-observability.namespace" . }}
+  labels:
+    {{- include "tentacular-observability.labels" . | nindent 4 }}
+    app.kubernetes.io/component: signoz
+  {{- if $annotations }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.hostname | quote }}
+      secretName: {{ .Values.ingress.tls.secretName | default "signoz-tls" | quote }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.hostname | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: signoz
+                port:
+                  number: 8080
+{{- end }}

--- a/charts/tentacular-observability/templates/traefik-middleware.yaml
+++ b/charts/tentacular-observability/templates/traefik-middleware.yaml
@@ -1,18 +1,13 @@
-{{- if .Values.oauth2Proxy.enabled }}
-apiVersion: traefik.io/v1alpha1
-kind: Middleware
-metadata:
-  name: signoz-forward-auth
-  namespace: {{ include "tentacular-observability.namespace" . }}
-  labels:
-    {{- include "tentacular-observability.labels" . | nindent 4 }}
-    app.kubernetes.io/component: oauth2-proxy
-spec:
-  forwardAuth:
-    address: http://oauth2-proxy.{{ include "tentacular-observability.namespace" . }}.svc.cluster.local:4180/oauth2/auth
-    trustForwardHeader: true
-    authResponseHeaders:
-      - X-Auth-Request-User
-      - X-Auth-Request-Email
-      - X-Auth-Request-Groups
-{{- end }}
+{{/*
+Traefik forwardAuth middleware for SigNoz.
+
+NOTE: This middleware is NOT currently used. The SigNoz ingress routes
+traffic through oauth2-proxy as a reverse proxy, which handles both
+authentication and proxying to SigNoz. This is more compatible across
+ingress controllers than forwardAuth (which requires controller-specific
+error handling for 401->redirect).
+
+This file is retained for future use if the architecture switches to
+forwardAuth mode (e.g., with an ingress controller that supports
+auth-signin error pages natively).
+*/}}

--- a/charts/tentacular-observability/templates/traefik-middleware.yaml
+++ b/charts/tentacular-observability/templates/traefik-middleware.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.oauth2Proxy.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: signoz-forward-auth
+  namespace: {{ include "tentacular-observability.namespace" . }}
+  labels:
+    {{- include "tentacular-observability.labels" . | nindent 4 }}
+    app.kubernetes.io/component: oauth2-proxy
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.{{ include "tentacular-observability.namespace" . }}.svc.cluster.local:4180/oauth2/auth
+    trustForwardHeader: true
+    authResponseHeaders:
+      - X-Auth-Request-User
+      - X-Auth-Request-Email
+      - X-Auth-Request-Groups
+{{- end }}

--- a/charts/tentacular-observability/values.yaml
+++ b/charts/tentacular-observability/values.yaml
@@ -102,3 +102,66 @@ networkPolicy:
   # -- When true, create a NetworkPolicy allowing OTLP ingress on 4317/4318
   # from all namespaces. Disable only if you manage NetworkPolicy externally.
   create: true
+
+# -- oauth2-proxy authentication for the SigNoz UI.
+# Deploys oauth2-proxy as a Keycloak OIDC gatekeeper in front of SigNoz.
+# SigNoz Community Edition lacks native OIDC — this provides the auth gate
+# at the Traefik ingress layer via forwardAuth middleware.
+oauth2Proxy:
+  # -- Enable oauth2-proxy deployment and Traefik forwardAuth middleware
+  enabled: false
+  image:
+    # -- oauth2-proxy image
+    repository: quay.io/oauth2-proxy/oauth2-proxy
+    # -- oauth2-proxy image tag
+    tag: "v7.7.1"
+    pullPolicy: IfNotPresent
+  # -- Replica count
+  replicaCount: 1
+  # -- Resource requests and limits
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  # -- Keycloak OIDC issuer URL (e.g., https://auth.example.com/realms/tentacular)
+  issuerURL: ""
+  # -- OIDC client ID (must match keycloak.clients.signoz.clientId in tentacular-platform)
+  clientID: "signoz"
+  # -- OIDC client secret (must match keycloak.clients.signoz.clientSecret)
+  clientSecret: ""
+  # -- Random cookie secret (32 bytes, base64-encoded). Generate with:
+  #    openssl rand -base64 32
+  cookieSecret: ""
+  # -- Use an existing Secret instead of creating one from the values above.
+  # Required keys: client-id, client-secret, cookie-secret
+  existingSecret: ""
+  # -- Cookie domain (e.g., .eastus-dev1.ospo-dev.miralabs.dev)
+  cookieDomain: ""
+  # -- Keycloak group required for access. Empty string allows any authenticated user.
+  allowedGroup: "/signoz-admins"
+  # -- Email domains allowed. Use ["*"] to allow any domain (Keycloak is the gatekeeper).
+  emailDomains:
+    - "*"
+
+# -- SigNoz Ingress configuration.
+# Creates a Kubernetes Ingress for the SigNoz frontend with optional
+# oauth2-proxy forwardAuth middleware.
+ingress:
+  # -- Enable SigNoz Ingress
+  enabled: false
+  # -- SigNoz hostname (e.g., tentacle-monitor.eastus-dev1.ospo-dev.miralabs.dev)
+  hostname: ""
+  # -- Ingress class name (e.g., traefik)
+  className: ""
+  tls:
+    # -- Enable TLS on the Ingress
+    enabled: false
+    # -- TLS secret name (defaults to signoz-tls)
+    secretName: ""
+    # -- cert-manager ClusterIssuer name
+    clusterIssuer: "letsencrypt-prod"
+  # -- Additional annotations for the Ingress
+  annotations: {}

--- a/charts/tentacular-observability/values.yaml
+++ b/charts/tentacular-observability/values.yaml
@@ -141,7 +141,7 @@ oauth2Proxy:
   # -- Cookie domain (e.g., .eastus-dev1.ospo-dev.miralabs.dev)
   cookieDomain: ""
   # -- Keycloak group required for access. Empty string allows any authenticated user.
-  allowedGroup: "/signoz-admins"
+  allowedGroup: "signoz-admins"
   # -- Email domains allowed. Use ["*"] to allow any domain (Keycloak is the gatekeeper).
   emailDomains:
     - "*"

--- a/charts/tentacular-platform/templates/keycloak-realm-configmap.yaml
+++ b/charts/tentacular-platform/templates/keycloak-realm-configmap.yaml
@@ -19,6 +19,9 @@ Client configuration:
                     direct access grants
   chroma          - CONFIDENTIAL client for the Next.js enclave UI
                     Flows: authorization code (NextAuth server-side)
+  signoz          - CONFIDENTIAL client for the SigNoz observability UI
+                    Flows: authorization code (oauth2-proxy at Traefik ingress)
+                    SigNoz CE lacks native OIDC; oauth2-proxy provides the gate.
 */}}
 {{- if .Values.keycloak.enabled }}
 {{- $kcScheme := ternary "https" "http" .Values.ingress.tls.enabled }}
@@ -29,6 +32,7 @@ Client configuration:
 {{- end }}
 {{- $mcpHost = $mcpHost | default (printf "tentacular-mcp.%s" .Values.global.domain) }}
 {{- $chromaHost := .Values.keycloak.clients.chroma.hostname | default (printf "chroma.%s" .Values.global.domain) }}
+{{- $signozHost := .Values.keycloak.clients.signoz.hostname | default (printf "tentacle-monitor.%s" .Values.global.domain) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -110,6 +114,56 @@ data:
           ],
           "webOrigins": ["+"],
           "defaultClientScopes": ["openid", "email", "profile"]
+        },
+        {
+          "clientId": {{ .Values.keycloak.clients.signoz.clientId | default "signoz" | quote }},
+          "name": "SigNoz (Observability UI)",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "clientAuthenticatorType": "client-secret",
+          "secret": {{ .Values.keycloak.clients.signoz.clientSecret | default "" | quote }},
+          "publicClient": false,
+          "standardFlowEnabled": true,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "authorizationServicesEnabled": false,
+          "redirectUris": [
+            "{{ $kcScheme }}://{{ $signozHost }}/oauth2/callback"
+          ],
+          "webOrigins": ["+"],
+          "defaultClientScopes": ["openid", "email", "profile", "groups"]
+        }
+      ],
+      "clientScopes": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true",
+            "consent.screen.text": "Group membership"
+          },
+          "protocolMappers": [
+            {
+              "name": "groups",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-group-membership-mapper",
+              "consentRequired": false,
+              "config": {
+                "full.path": "false",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "groups",
+                "userinfo.token.claim": "true"
+              }
+            }
+          ]
+        }
+      ],
+      "groups": [
+        {
+          "name": "signoz-admins",
+          "path": "/signoz-admins"
         }
       ]
     }

--- a/charts/tentacular-platform/templates/keycloak-realm-configmap.yaml
+++ b/charts/tentacular-platform/templates/keycloak-realm-configmap.yaml
@@ -131,7 +131,22 @@ data:
             "{{ $kcScheme }}://{{ $signozHost }}/oauth2/callback"
           ],
           "webOrigins": ["+"],
-          "defaultClientScopes": ["openid", "email", "profile", "groups"]
+          "defaultClientScopes": ["openid", "email", "profile", "groups"],
+          "protocolMappers": [
+            {
+              "name": "audience",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-audience-mapper",
+              "consentRequired": false,
+              "config": {
+                "included.client.audience": "signoz",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "included.custom.audience": "",
+                "userinfo.token.claim": "false"
+              }
+            }
+          ]
         }
       ],
       "clientScopes": [

--- a/charts/tentacular-platform/values.yaml
+++ b/charts/tentacular-platform/values.yaml
@@ -342,6 +342,14 @@ keycloak:
       clientSecret: ""
       # -- Chroma hostname for redirect URIs
       hostname: ""
+    # -- SigNoz observability UI client (CONFIDENTIAL).
+    # Uses authorization code flow via oauth2-proxy at the Traefik ingress layer.
+    # SigNoz Community Edition lacks native OIDC — oauth2-proxy provides the gate.
+    signoz:
+      clientId: "signoz"
+      clientSecret: ""
+      # -- SigNoz hostname for redirect URIs
+      hostname: ""
 
 # -- keycloakx subchart configuration (passed through to codecentric/keycloakx)
 # See https://github.com/codecentric/helm-charts/tree/master/charts/keycloakx

--- a/deploy/traefik/values.yaml
+++ b/deploy/traefik/values.yaml
@@ -16,14 +16,19 @@ hostNetwork: true
 service:
   type: ClusterIP
 
-# Global HTTP-to-HTTPS redirect for all ingresses.
+# Recreate strategy is required for hostNetwork — only one pod can bind
+# to ports 80/443 at a time, so RollingUpdate deadlocks.
+updateStrategy:
+  type: Recreate
+
+# Global HTTP-to-HTTPS redirect for all ingresses (308 Permanent Redirect).
 ports:
   web:
-    redirectTo:
-      port: websecure
-  websecure:
-    tls:
-      enabled: true
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
 
 # RBAC: allow Traefik to read resources across all namespaces.
 rbac:

--- a/deploy/traefik/values.yaml
+++ b/deploy/traefik/values.yaml
@@ -1,0 +1,40 @@
+# Traefik Helm values for Tentacular clusters.
+#
+# Install/upgrade:
+#   helm repo add traefik https://traefik.github.io/charts
+#   helm upgrade --install traefik traefik/traefik \
+#     --namespace traefik --create-namespace \
+#     -f deploy/traefik/values.yaml
+#
+# This binds Traefik directly to the node's ports 80/443 via hostNetwork.
+# Acceptable for single-node dev clusters. For multi-node production,
+# switch to a LoadBalancer service or DaemonSet with hostPort.
+
+# Bind directly to node ports 80/443 (no LoadBalancer needed).
+hostNetwork: true
+
+service:
+  type: ClusterIP
+
+# Global HTTP-to-HTTPS redirect for all ingresses.
+ports:
+  web:
+    redirectTo:
+      port: websecure
+  websecure:
+    tls:
+      enabled: true
+
+# RBAC: allow Traefik to read resources across all namespaces.
+rbac:
+  enabled: true
+
+# Enable Traefik CRD provider (Middleware, IngressRoute, etc.).
+# allowCrossNamespace lets Traefik read Middleware CRDs from any namespace,
+# which is required for the SigNoz forwardAuth middleware in tentacular-observability.
+providers:
+  kubernetesCRD:
+    enabled: true
+    allowCrossNamespace: true
+  kubernetesIngress:
+    enabled: true


### PR DESCRIPTION
## Summary

- Adds oauth2-proxy as a Keycloak OIDC authentication gateway for SigNoz (SigNoz CE lacks native OIDC support)
- oauth2-proxy runs in reverse-proxy mode: Traefik -> oauth2-proxy -> SigNoz, handling both auth and proxying
- Only members of the `signoz-admins` Keycloak group can access SigNoz (403 for others)
- Adds global HTTP-to-HTTPS redirect for all Traefik ingresses (308 Permanent Redirect)
- Adds `signoz` OIDC client, `groups` client scope with membership mapper, and audience mapper to Keycloak realm config

## Security

Closes NSG-C1 (CRITICAL): SigNoz was exposed to the internet with zero authentication.

## Files

**New (7):** oauth2-proxy deployment, service, secret, ingress templates; signoz ingress; traefik middleware (reserved); traefik values
**Modified (4):** observability values.yaml, networkpolicy.yaml, platform values.yaml, keycloak-realm-configmap.yaml

## Deployment

Already deployed and verified on eastus-dev1:
1. Traefik upgraded (revision 8) with global HTTPS redirect + Recreate strategy
2. Keycloak signoz client + groups scope + signoz-admins group created via admin API
3. oauth2-proxy deployed, auth flow verified end-to-end (Google SSO -> SigNoz dashboard)
4. HTTP->HTTPS redirect verified on all ingresses (tentacle-monitor, auth, tentacle-chroma)

## Test plan

- [ ] `helm template` renders cleanly with oauth2Proxy.enabled=true and =false
- [ ] Unauthenticated request to SigNoz URL returns 302 to Keycloak
- [ ] Authenticated user in signoz-admins group reaches SigNoz dashboard
- [ ] Authenticated user NOT in signoz-admins group gets 403
- [ ] HTTP requests to all ingresses redirect to HTTPS (308)
- [ ] oauth2-proxy pod healthy (liveness/readiness probes passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)