### PR TITLE
feat: enforce mandatory node descriptions in wf_apply and read from ConfigMap

### DIFF
--- a/pkg/tools/deploy.go
+++ b/pkg/tools/deploy.go
@@ -802,8 +802,7 @@ func validateNodeDescriptions(manifests []map[string]any) error {
 			return nil
 		}
 		if jsonErr := json.Unmarshal([]byte(nodesJSON), &nodeNames); jsonErr != nil {
-			// Malformed annotation — skip validation rather than blocking deploy.
-			return nil //nolint:nilerr // intentional: malformed annotation is not a deploy blocker
+			return fmt.Errorf("malformed tentacular.io/nodes annotation: %w", jsonErr)
 		}
 		break
 	}

--- a/pkg/tools/deploy.go
+++ b/pkg/tools/deploy.go
@@ -2,10 +2,12 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -239,6 +241,9 @@ func registerDeployTools(srv *mcp.Server, client *k8s.Client, sched *scheduler.S
 				IsUpdate:            isUpdate,
 				ExistingAnnotations: existingAnnotations,
 			})
+		}
+		if err := validateNodeDescriptions(params.Manifests); err != nil {
+			return nil, WorkflowApplyResult{}, err
 		}
 		result, err := handleWorkflowApply(ctx, client, params)
 		if err == nil {
@@ -773,6 +778,77 @@ type dependencyYAML struct {
 	Protocol string `yaml:"protocol"`
 	Host     string `yaml:"host"`
 	Version  string `yaml:"version"`
+}
+
+// validateNodeDescriptions checks that every node listed in the Deployment's
+// tentacular.io/nodes annotation has a corresponding entry in the metadata
+// ConfigMap's node_descriptions key. Returns nil when no Deployment manifest
+// is present, when the annotation is absent (pre-description deploys), or when
+// all nodes have descriptions.
+func validateNodeDescriptions(manifests []map[string]any) error {
+	// Step 1: find the Deployment and read tentacular.io/nodes annotation.
+	var nodeNames []string
+	foundDeployment := false
+	for _, m := range manifests {
+		obj := &unstructured.Unstructured{Object: m}
+		if obj.GetKind() != "Deployment" {
+			continue
+		}
+		foundDeployment = true
+		ann := obj.GetAnnotations()
+		nodesJSON, ok := ann["tentacular.io/nodes"]
+		if !ok || nodesJSON == "" {
+			// No annotation — pre-description deploy, skip validation.
+			return nil
+		}
+		if jsonErr := json.Unmarshal([]byte(nodesJSON), &nodeNames); jsonErr != nil {
+			// Malformed annotation — skip validation rather than blocking deploy.
+			return nil //nolint:nilerr // intentional: malformed annotation is not a deploy blocker
+		}
+		break
+	}
+	if !foundDeployment || len(nodeNames) == 0 {
+		return nil
+	}
+
+	// Step 2: find the metadata ConfigMap (name ends with "-metadata") and read
+	// the node_descriptions JSON key.
+	described := make(map[string]bool, len(nodeNames))
+	for _, m := range manifests {
+		obj := &unstructured.Unstructured{Object: m}
+		if obj.GetKind() != "ConfigMap" {
+			continue
+		}
+		if !strings.HasSuffix(obj.GetName(), "-metadata") {
+			continue
+		}
+		data, ok, _ := unstructured.NestedStringMap(obj.Object, "data")
+		if !ok {
+			break
+		}
+		descJSON, ok := data["node_descriptions"]
+		if !ok {
+			break
+		}
+		var descs []NodeMeta
+		if err := json.Unmarshal([]byte(descJSON), &descs); err != nil {
+			break
+		}
+		for _, d := range descs {
+			if d.Description != "" {
+				described[d.Name] = true
+			}
+		}
+		break
+	}
+
+	// Step 3: verify every node has a description.
+	for _, name := range nodeNames {
+		if !described[name] {
+			return fmt.Errorf("node %q: description is required (add description field in workflow.yaml)", name)
+		}
+	}
+	return nil
 }
 
 // extractModuleDeps inspects the manifests for a ConfigMap containing

--- a/pkg/tools/deploy_test.go
+++ b/pkg/tools/deploy_test.go
@@ -884,3 +884,154 @@ func TestWorkflowApplyConfigMapLargeDataIntegrity(t *testing.T) {
 	checkStringKey("key-small-2", smallValue2)
 	checkStringKey("key-large", largeValue)
 }
+
+// makeNodeDescJSON marshals a slice of name/description pairs into JSON for use
+// in ConfigMap test fixtures.
+func makeNodeDescJSON(t *testing.T, descs []NodeMeta) string {
+	t.Helper()
+	b, err := json.Marshal(descs)
+	if err != nil {
+		t.Fatalf("marshal node descriptions: %v", err)
+	}
+	return string(b)
+}
+
+// makeNodesAnnotation marshals a slice of node names into JSON for use in
+// Deployment annotation test fixtures.
+func makeNodesAnnotation(t *testing.T, names []string) string {
+	t.Helper()
+	b, err := json.Marshal(names)
+	if err != nil {
+		t.Fatalf("marshal nodes annotation: %v", err)
+	}
+	return string(b)
+}
+
+// TestValidateNodeDescriptions_NoDeployment verifies that manifests with no
+// Deployment skip validation (backwards compat — ConfigMap-only apply).
+func TestValidateNodeDescriptions_NoDeployment(t *testing.T) {
+	manifests := []map[string]any{
+		{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "my-wf-metadata"},
+			"data":       map[string]any{},
+		},
+	}
+	if err := validateNodeDescriptions(manifests); err != nil {
+		t.Errorf("expected nil for no Deployment, got: %v", err)
+	}
+}
+
+// TestValidateNodeDescriptions_NoNodesAnnotation verifies that a Deployment
+// without tentacular.io/nodes annotation skips validation (pre-description deploy).
+func TestValidateNodeDescriptions_NoNodesAnnotation(t *testing.T) {
+	manifests := []map[string]any{
+		{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"name":        "my-wf",
+				"annotations": map[string]any{},
+			},
+		},
+	}
+	if err := validateNodeDescriptions(manifests); err != nil {
+		t.Errorf("expected nil when nodes annotation absent, got: %v", err)
+	}
+}
+
+// TestValidateNodeDescriptions_AllDescribed verifies that manifests with complete
+// node descriptions are accepted.
+func TestValidateNodeDescriptions_AllDescribed(t *testing.T) {
+	nodesAnn := makeNodesAnnotation(t, []string{"fetch", "analyze"})
+	descJSON := makeNodeDescJSON(t, []NodeMeta{
+		{Name: "fetch", Description: "Fetches data"},
+		{Name: "analyze", Description: "Analyzes data"},
+	})
+	manifests := []map[string]any{
+		{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"name": "my-wf",
+				"annotations": map[string]any{
+					"tentacular.io/nodes": nodesAnn,
+				},
+			},
+		},
+		{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "my-wf-metadata"},
+			"data":       map[string]any{"node_descriptions": descJSON},
+		},
+	}
+	if err := validateNodeDescriptions(manifests); err != nil {
+		t.Errorf("expected nil for complete descriptions, got: %v", err)
+	}
+}
+
+// TestValidateNodeDescriptions_MissingConfigMapKey verifies that manifests with
+// nodes but no node_descriptions ConfigMap key are rejected.
+func TestValidateNodeDescriptions_MissingConfigMapKey(t *testing.T) {
+	nodesAnn := makeNodesAnnotation(t, []string{"fetch", "analyze"})
+	manifests := []map[string]any{
+		{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"name": "my-wf",
+				"annotations": map[string]any{
+					"tentacular.io/nodes": nodesAnn,
+				},
+			},
+		},
+		{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "my-wf-metadata"},
+			"data":       map[string]any{},
+		},
+	}
+	err := validateNodeDescriptions(manifests)
+	if err == nil {
+		t.Error("expected error when node_descriptions key is absent, got nil")
+	}
+}
+
+// TestValidateNodeDescriptions_PartialDescriptions verifies that manifests where
+// one or more nodes lack a description entry are rejected.
+func TestValidateNodeDescriptions_PartialDescriptions(t *testing.T) {
+	nodesAnn := makeNodesAnnotation(t, []string{"fetch", "analyze", "report"})
+	// Only "fetch" and "analyze" have descriptions; "report" is missing.
+	descJSON := makeNodeDescJSON(t, []NodeMeta{
+		{Name: "fetch", Description: "Fetches data"},
+		{Name: "analyze", Description: "Analyzes data"},
+	})
+	manifests := []map[string]any{
+		{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"name": "my-wf",
+				"annotations": map[string]any{
+					"tentacular.io/nodes": nodesAnn,
+				},
+			},
+		},
+		{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "my-wf-metadata"},
+			"data":       map[string]any{"node_descriptions": descJSON},
+		},
+	}
+	err := validateNodeDescriptions(manifests)
+	if err == nil {
+		t.Error("expected error for partial descriptions, got nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "report") {
+		t.Errorf("error should mention missing node %q, got: %v", "report", err)
+	}
+}

--- a/pkg/tools/deploy_test.go
+++ b/pkg/tools/deploy_test.go
@@ -1035,3 +1035,28 @@ func TestValidateNodeDescriptions_PartialDescriptions(t *testing.T) {
 		t.Errorf("error should mention missing node %q, got: %v", "report", err)
 	}
 }
+
+// TestValidateNodeDescriptions_MalformedAnnotation verifies that a Deployment
+// with a tentacular.io/nodes annotation that is present but not valid JSON is
+// rejected (fail-closed, not silently skipped).
+func TestValidateNodeDescriptions_MalformedAnnotation(t *testing.T) {
+	manifests := []map[string]any{
+		{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"name": "my-wf",
+				"annotations": map[string]any{
+					"tentacular.io/nodes": `not-valid-json`,
+				},
+			},
+		},
+	}
+	err := validateNodeDescriptions(manifests)
+	if err == nil {
+		t.Error("expected error for malformed nodes annotation, got nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "malformed tentacular.io/nodes annotation") {
+		t.Errorf("error message unexpected: %v", err)
+	}
+}

--- a/pkg/tools/deploy_test.go
+++ b/pkg/tools/deploy_test.go
@@ -1060,3 +1060,90 @@ func TestValidateNodeDescriptions_MalformedAnnotation(t *testing.T) {
 		t.Errorf("error message unexpected: %v", err)
 	}
 }
+
+// TestValidateNodeDescriptions_EmptyDescriptionString verifies that a node entry
+// in node_descriptions with an empty description field is treated as missing.
+func TestValidateNodeDescriptions_EmptyDescriptionString(t *testing.T) {
+	nodesAnn := makeNodesAnnotation(t, []string{"fetch"})
+	descJSON := makeNodeDescJSON(t, []NodeMeta{
+		{Name: "fetch", Description: ""},
+	})
+	manifests := []map[string]any{
+		{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"name": "my-wf",
+				"annotations": map[string]any{
+					"tentacular.io/nodes": nodesAnn,
+				},
+			},
+		},
+		{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "my-wf-metadata"},
+			"data":       map[string]any{"node_descriptions": descJSON},
+		},
+	}
+	err := validateNodeDescriptions(manifests)
+	if err == nil {
+		t.Error("expected error when node description is empty string, got nil")
+	}
+}
+
+// TestValidateNodeDescriptions_MalformedNodeDescriptionsJSON verifies that
+// malformed JSON in the node_descriptions ConfigMap key causes all nodes to fail.
+func TestValidateNodeDescriptions_MalformedNodeDescriptionsJSON(t *testing.T) {
+	nodesAnn := makeNodesAnnotation(t, []string{"fetch"})
+	manifests := []map[string]any{
+		{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"name": "my-wf",
+				"annotations": map[string]any{
+					"tentacular.io/nodes": nodesAnn,
+				},
+			},
+		},
+		{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "my-wf-metadata"},
+			"data":       map[string]any{"node_descriptions": `not-valid-json{{{`},
+		},
+	}
+	err := validateNodeDescriptions(manifests)
+	if err == nil {
+		t.Error("expected error when node_descriptions JSON is malformed, got nil")
+	}
+}
+
+// TestValidateNodeDescriptions_EmptyDescriptionsArray verifies that an empty
+// node_descriptions array causes all nodes to fail validation.
+func TestValidateNodeDescriptions_EmptyDescriptionsArray(t *testing.T) {
+	nodesAnn := makeNodesAnnotation(t, []string{"fetch"})
+	manifests := []map[string]any{
+		{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"name": "my-wf",
+				"annotations": map[string]any{
+					"tentacular.io/nodes": nodesAnn,
+				},
+			},
+		},
+		{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "my-wf-metadata"},
+			"data":       map[string]any{"node_descriptions": `[]`},
+		},
+	}
+	err := validateNodeDescriptions(manifests)
+	if err == nil {
+		t.Error("expected error when node_descriptions array is empty, got nil")
+	}
+}

--- a/pkg/tools/discover.go
+++ b/pkg/tools/discover.go
@@ -151,23 +151,23 @@ type WfDescribeResult struct {
 	ParamsSchema  string            `json:"params_schema,omitempty"`
 	// ContractSummary maps to the "contract" key in the metadata ConfigMap.
 	// The field name is more descriptive for API consumers.
-	ContractSummary string           `json:"contract_summary,omitempty"`
-	Readme          string           `json:"readme,omitempty"`
-	MetadataRef     string           `json:"metadata_ref,omitempty"`
-	ScaffoldName    string           `json:"scaffold_name,omitempty"`
+	ContractSummary  string           `json:"contract_summary,omitempty"`
+	Readme           string           `json:"readme,omitempty"`
+	MetadataRef      string           `json:"metadata_ref,omitempty"`
+	ScaffoldName     string           `json:"scaffold_name,omitempty"`
 	Nodes            []string         `json:"nodes,omitempty"`
 	NodeDescriptions []NodeMeta       `json:"node_descriptions,omitempty"`
 	Sidecars         []SidecarMeta    `json:"sidecars,omitempty"`
-	Dependencies    []DependencyMeta `json:"dependencies,omitempty"`
-	Prompts         []PromptEntry    `json:"prompts,omitempty"`
-	Templates       []TemplateEntry  `json:"templates,omitempty"`
-	Edges           [][2]string      `json:"edges,omitempty"`
-	EnclaveMembers  []string         `json:"enclave_members,omitempty"`
-	Tags            []string         `json:"tags,omitempty"`
-	Triggers        []string         `json:"triggers,omitempty"`
-	Replicas        int32            `json:"replicas"`
-	ReadyReplicas   int32            `json:"ready_replicas"`
-	Ready           bool             `json:"ready"`
+	Dependencies     []DependencyMeta `json:"dependencies,omitempty"`
+	Prompts          []PromptEntry    `json:"prompts,omitempty"`
+	Templates        []TemplateEntry  `json:"templates,omitempty"`
+	Edges            [][2]string      `json:"edges,omitempty"`
+	EnclaveMembers   []string         `json:"enclave_members,omitempty"`
+	Tags             []string         `json:"tags,omitempty"`
+	Triggers         []string         `json:"triggers,omitempty"`
+	Replicas         int32            `json:"replicas"`
+	ReadyReplicas    int32            `json:"ready_replicas"`
+	Ready            bool             `json:"ready"`
 }
 
 func registerDiscoverTools(srv *mcp.Server, client *k8s.Client, eval *authz.Evaluator) {
@@ -545,15 +545,25 @@ func handleWfDescribe(ctx context.Context, client *k8s.Client, params WfDescribe
 			var promptsDoc struct {
 				Prompts   []PromptEntry   `yaml:"prompts"`
 				Templates []TemplateEntry `yaml:"templates"`
-				Nodes     []NodeMeta      `yaml:"nodes"`
 			}
 			if yamlErr := yaml.Unmarshal([]byte(v), &promptsDoc); yamlErr == nil {
 				result.Prompts = promptsDoc.Prompts
 				result.Templates = promptsDoc.Templates
-				result.NodeDescriptions = promptsDoc.Nodes
 			} else {
 				slog.Warn("wf_describe: invalid YAML in prompts ConfigMap key",
 					"deployment", params.Name, "error", yamlErr)
+			}
+		}
+		// node_descriptions: JSON array of [{name, description}] written by the builder
+		// (tentacular/pkg/builder/metadata.go). Falls back to empty when the key is absent
+		// (pre-description deploys).
+		if v, ok := metaCM.Data["node_descriptions"]; ok {
+			var descs []NodeMeta
+			if jsonErr := json.Unmarshal([]byte(v), &descs); jsonErr == nil {
+				result.NodeDescriptions = descs
+			} else {
+				slog.Warn("wf_describe: invalid JSON in node_descriptions ConfigMap key",
+					"deployment", params.Name, "error", jsonErr)
 			}
 		}
 	}

--- a/pkg/tools/discover_metadata_test.go
+++ b/pkg/tools/discover_metadata_test.go
@@ -578,19 +578,18 @@ func TestWfDescribe_NodeDescriptionsPresent(t *testing.T) {
 		t.Fatalf("create deployment: %v", err)
 	}
 
+	nodeDescs, _ := json.Marshal([]NodeMeta{
+		{Name: "fetch-data", Description: "Fetches data from external API"},
+		{Name: "analyze", Description: "Runs LLM analysis on fetched data"},
+	})
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "nodedesc-wf-metadata",
 			Namespace: "nodedesc-ns",
 		},
 		Data: map[string]string{
-			"prompts": `version: "1"
-nodes:
-  - name: fetch-data
-    description: "Fetches data from external API"
-  - name: analyze
-    description: "Runs LLM analysis on fetched data"
-prompts:
+			"node_descriptions": string(nodeDescs),
+			"prompts": `prompts:
   - node: analyze
     name: data-analysis
     model: claude-3-haiku
@@ -609,7 +608,7 @@ prompts:
 		t.Fatalf("handleWfDescribe: %v", err)
 	}
 
-	// NodeDescriptions
+	// NodeDescriptions come from the node_descriptions JSON key.
 	if len(result.NodeDescriptions) != 2 {
 		t.Fatalf("NodeDescriptions: got %d, want 2", len(result.NodeDescriptions))
 	}
@@ -626,7 +625,7 @@ prompts:
 		t.Errorf("NodeDescriptions[1].Description = %q", result.NodeDescriptions[1].Description)
 	}
 
-	// Prompts should still parse correctly alongside nodes.
+	// Prompts should still parse correctly from the prompts key.
 	if len(result.Prompts) != 1 {
 		t.Fatalf("Prompts: got %d, want 1", len(result.Prompts))
 	}


### PR DESCRIPTION
## Summary
- `wf_describe` reads node descriptions from `node_descriptions` ConfigMap JSON key (not prompts YAML)
- `wf_apply` enforces that all nodes have descriptions (server-side enforcement)
- Malformed `tentacular.io/nodes` annotation fails closed (security fix)
- Backwards compatible: old deploys without annotation skip validation

## Test plan
- [x] `make test` passes
- [x] `golangci-lint run ./...` clean
- [x] 9 test cases for `validateNodeDescriptions` (including edge cases)
- [x] Updated `TestWfDescribe_NodeDescriptionsPresent` for new JSON key format

Part of the v0.9.0-rc.13 release. See also randybias/tentacular#124

🤖 Generated with [Claude Code](https://claude.com/claude-code)