### PR TITLE
feat: enclave paradigm - namespace to enclave param renames

### DIFF
--- a/pkg/k8s/profile.go
+++ b/pkg/k8s/profile.go
@@ -63,7 +63,7 @@ type ClusterProfile struct {
 	K8sVersion     string             `json:"k8sVersion"`
 	Distribution   string             `json:"distribution"`
 	PodSecurity    string             `json:"podSecurity"`
-	Namespace      string             `json:"namespace"`
+	Namespace      string             `json:"enclave"` // enclave name = K8s namespace name
 	RWXNote        string             `json:"rwxNote"`
 	RuntimeClasses []RuntimeClassInfo `json:"runtimeClasses"`
 	Ingress        []string           `json:"ingress"`

--- a/pkg/tools/audit.go
+++ b/pkg/tools/audit.go
@@ -18,7 +18,7 @@ import (
 
 // AuditRbacParams are the parameters for audit_rbac.
 type AuditRbacParams struct {
-	Namespace string `json:"namespace" jsonschema:"Namespace to audit RBAC in"`
+	Namespace string `json:"enclave" jsonschema:"Enclave to audit RBAC in"`
 }
 
 // AuditFinding is a single RBAC audit finding.
@@ -37,7 +37,7 @@ type AuditRbacResult struct {
 
 // AuditNetpolParams are the parameters for audit_netpol.
 type AuditNetpolParams struct {
-	Namespace string `json:"namespace" jsonschema:"Namespace to audit network policies in"`
+	Namespace string `json:"enclave" jsonschema:"Enclave to audit network policies in"`
 }
 
 // NetpolInfo is a single network policy in the audit result.
@@ -63,7 +63,7 @@ type AuditNetpolResult struct {
 
 // AuditPsaParams are the parameters for audit_psa.
 type AuditPsaParams struct {
-	Namespace string `json:"namespace" jsonschema:"Namespace to audit Pod Security Admission configuration in"`
+	Namespace string `json:"enclave" jsonschema:"Enclave to audit Pod Security Admission configuration in"`
 }
 
 // AuditPsaFinding is a single PSA audit finding.
@@ -85,7 +85,7 @@ type AuditPsaResult struct {
 func registerAuditTools(srv *mcp.Server, client *k8s.Client, eval *authz.Evaluator) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "audit_rbac",
-		Description: "Audit RBAC in a namespace: scan for wildcard verbs/resources, sensitive access, escalation paths (bind/escalate/impersonate verbs), and ClusterRoleBindings targeting namespace service accounts. Returns findings with remediation suggestions.",
+		Description: "Audit RBAC in an enclave: scan for wildcard verbs/resources, sensitive access, escalation paths (bind/escalate/impersonate verbs), and ClusterRoleBindings targeting enclave service accounts. Returns findings with remediation suggestions.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Audit RBAC Configuration",
 			ReadOnlyHint:    true,
@@ -107,7 +107,7 @@ func registerAuditTools(srv *mcp.Server, client *k8s.Client, eval *authz.Evaluat
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "audit_netpol",
-		Description: "Audit network policies in a namespace: check for default-deny policy, missing egress restrictions, overly broad allow rules, cross-namespace ingress via empty namespaceSelector, and list all policies. Returns findings with remediation suggestions.",
+		Description: "Audit network policies in an enclave: check for default-deny policy, missing egress restrictions, overly broad allow rules, cross-namespace ingress via empty namespaceSelector, and list all policies. Returns findings with remediation suggestions.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Audit Network Policies",
 			ReadOnlyHint:    true,
@@ -129,7 +129,7 @@ func registerAuditTools(srv *mcp.Server, client *k8s.Client, eval *authz.Evaluat
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "audit_psa",
-		Description: "Audit Pod Security Admission labels on a namespace: check enforce/audit/warn levels, flag privileged or missing enforcement, detect audit/warn level mismatches, and return remediation suggestions.",
+		Description: "Audit Pod Security Admission labels on an enclave: check enforce/audit/warn levels, flag privileged or missing enforcement, detect audit/warn level mismatches, and return remediation suggestions.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Audit Pod Security Admission",
 			ReadOnlyHint:    true,

--- a/pkg/tools/clusterops.go
+++ b/pkg/tools/clusterops.go
@@ -14,7 +14,7 @@ import (
 
 // ClusterPreflightParams are the parameters for cluster_preflight.
 type ClusterPreflightParams struct {
-	Namespace string `json:"namespace" jsonschema:"Namespace to run preflight checks against"`
+	Namespace string `json:"enclave" jsonschema:"Enclave to run preflight checks against"`
 }
 
 // ClusterPreflightResult is the result of cluster_preflight.
@@ -25,13 +25,13 @@ type ClusterPreflightResult struct {
 
 // ClusterProfileParams are the parameters for cluster_profile.
 type ClusterProfileParams struct {
-	Namespace string `json:"namespace,omitempty" jsonschema:"Optional namespace to include quota and limit range details"`
+	Namespace string `json:"enclave,omitempty" jsonschema:"Optional enclave to include quota and limit range details"`
 }
 
 func registerClusterOpsTools(srv *mcp.Server, client *k8s.Client, exoCtrl *exoskeleton.Controller, eval *authz.Evaluator) {
 	mcp.AddTool(srv, &mcp.Tool{
-		Name:        "cluster_preflight",
-		Description: "Run preflight checks for a namespace: API reachability, namespace existence, RBAC, and gVisor availability.",
+		Name:        "enclave_preflight",
+		Description: "Run preflight checks for an enclave: API reachability, enclave existence, RBAC, and gVisor availability.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Run Cluster Preflight Checks",
 			ReadOnlyHint:    true,

--- a/pkg/tools/deploy.go
+++ b/pkg/tools/deploy.go
@@ -63,7 +63,7 @@ var knownGVRs = []schema.GroupVersionResource{
 
 // WorkflowApplyParams are the parameters for wf_apply.
 type WorkflowApplyParams struct {
-	Namespace string           `json:"namespace" jsonschema:"Target namespace for the workflow"`
+	Namespace string           `json:"enclave" jsonschema:"Target enclave for the workflow"`
 	Name      string           `json:"name" jsonschema:"Deployment name for tracking resources"`
 	Mode      string           `json:"mode,omitempty" jsonschema:"Raw permission mode string (e.g. rwxrwx---). Defaults to enclave default mode."`
 	Manifests []map[string]any `json:"manifests" jsonschema:"List of Kubernetes manifest objects to apply"`
@@ -72,7 +72,7 @@ type WorkflowApplyParams struct {
 // WorkflowApplyResult is the result of wf_apply.
 type WorkflowApplyResult struct {
 	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
+	Namespace string `json:"enclave"`
 	Created   int    `json:"created"`
 	Updated   int    `json:"updated"`
 	Deleted   int    `json:"deleted"`
@@ -80,14 +80,14 @@ type WorkflowApplyResult struct {
 
 // WorkflowRemoveParams are the parameters for wf_remove.
 type WorkflowRemoveParams struct {
-	Namespace string `json:"namespace" jsonschema:"Namespace containing the workflow resources"`
+	Namespace string `json:"enclave" jsonschema:"Enclave containing the workflow resources"`
 	Name      string `json:"name" jsonschema:"Deployment name to remove"`
 }
 
 // WorkflowRemoveResult is the result of wf_remove.
 type WorkflowRemoveResult struct {
 	Name              string `json:"name"`
-	Namespace         string `json:"namespace"`
+	Namespace         string `json:"enclave"`
 	ExoCleanupDetails string `json:"exo_cleanup_details,omitempty"`
 	Deleted           int    `json:"deleted"`
 	ExoCleanedUp      bool   `json:"exo_cleaned_up,omitempty"`
@@ -95,7 +95,7 @@ type WorkflowRemoveResult struct {
 
 // WorkflowStatusParams are the parameters for wf_status.
 type WorkflowStatusParams struct {
-	Namespace string `json:"namespace" jsonschema:"Namespace containing the workflow resources"`
+	Namespace string `json:"enclave" jsonschema:"Enclave containing the workflow resources"`
 	Name      string `json:"name" jsonschema:"Deployment name to check status for"`
 	Detail    bool   `json:"detail,omitempty" jsonschema:"Include pods and events in the response"`
 }
@@ -127,7 +127,7 @@ type WorkflowEventInfo struct {
 // WorkflowStatusResult is the result of wf_status.
 type WorkflowStatusResult struct {
 	Name      string                   `json:"name"`
-	Namespace string                   `json:"namespace"`
+	Namespace string                   `json:"enclave"`
 	Version   string                   `json:"version,omitempty"`
 	Resources []WorkflowResourceStatus `json:"resources"`
 	Pods      []WorkflowPodInfo        `json:"pods,omitempty"`
@@ -140,7 +140,7 @@ type WorkflowStatusResult struct {
 func registerDeployTools(srv *mcp.Server, client *k8s.Client, sched *scheduler.Scheduler, exoCtrl *exoskeleton.Controller, eval *authz.Evaluator) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_apply",
-		Description: "Apply a set of Kubernetes manifests as a named deployment in a namespace. Uses release labels for tracking and garbage collection. Includes garbage collection of stale resources.",
+		Description: "Apply a set of Kubernetes manifests as a named deployment in an enclave. Uses release labels for tracking and garbage collection. Includes garbage collection of stale resources.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Apply Workflow Manifests",
 			ReadOnlyHint:    false,
@@ -272,7 +272,7 @@ func registerDeployTools(srv *mcp.Server, client *k8s.Client, sched *scheduler.S
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_remove",
-		Description: "Remove all resources belonging to a named deployment in a namespace. When exoskeleton cleanup is enabled, also drops backing-service data.",
+		Description: "Remove all resources belonging to a named deployment in an enclave. When exoskeleton cleanup is enabled, also drops backing-service data.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Remove Workflow Deployment",
 			ReadOnlyHint:    false,
@@ -323,7 +323,7 @@ func registerDeployTools(srv *mcp.Server, client *k8s.Client, sched *scheduler.S
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_status",
-		Description: "Get status of all resources belonging to a named deployment in a namespace.",
+		Description: "Get status of all resources belonging to a named deployment in an enclave.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Get Workflow Status",
 			ReadOnlyHint:    true,

--- a/pkg/tools/deploy_test.go
+++ b/pkg/tools/deploy_test.go
@@ -397,7 +397,7 @@ func TestWorkflowStatusResultJSONNameField(t *testing.T) {
 // TestWorkflowParamStructsJSONNameField verifies that all three param structs
 // accept the "name" JSON key (not the old "release" key).
 func TestWorkflowParamStructsJSONNameField(t *testing.T) {
-	applyJSON := `{"namespace":"ns","name":"rel","manifests":[]}`
+	applyJSON := `{"enclave":"ns","name":"rel","manifests":[]}`
 	var applyParams WorkflowApplyParams
 	if err := json.Unmarshal([]byte(applyJSON), &applyParams); err != nil {
 		t.Fatalf("unmarshal WorkflowApplyParams: %v", err)
@@ -406,7 +406,7 @@ func TestWorkflowParamStructsJSONNameField(t *testing.T) {
 		t.Errorf("WorkflowApplyParams Name: got %q, want rel", applyParams.Name)
 	}
 
-	removeJSON := `{"namespace":"ns","name":"rel"}`
+	removeJSON := `{"enclave":"ns","name":"rel"}`
 	var removeParams WorkflowRemoveParams
 	if err := json.Unmarshal([]byte(removeJSON), &removeParams); err != nil {
 		t.Fatalf("unmarshal WorkflowRemoveParams: %v", err)
@@ -415,7 +415,7 @@ func TestWorkflowParamStructsJSONNameField(t *testing.T) {
 		t.Errorf("WorkflowRemoveParams Name: got %q, want rel", removeParams.Name)
 	}
 
-	statusJSON := `{"namespace":"ns","name":"rel"}`
+	statusJSON := `{"enclave":"ns","name":"rel"}`
 	var statusParams WorkflowStatusParams
 	if err := json.Unmarshal([]byte(statusJSON), &statusParams); err != nil {
 		t.Fatalf("unmarshal WorkflowStatusParams: %v", err)

--- a/pkg/tools/discover.go
+++ b/pkg/tools/discover.go
@@ -96,7 +96,7 @@ type GitProvenance struct {
 
 // WfListParams are the parameters for wf_list.
 type WfListParams struct {
-	Namespace string `json:"namespace,omitempty" jsonschema:"Namespace to filter (optional, empty=all tentacular namespaces)"`
+	Namespace string `json:"enclave,omitempty" jsonschema:"Enclave to filter (optional, empty=all enclaves)"`
 	Owner     string `json:"owner,omitempty" jsonschema:"Filter by owner annotation (optional)"`
 	Tag       string `json:"tag,omitempty" jsonschema:"Filter by tag (optional)"`
 }
@@ -104,7 +104,7 @@ type WfListParams struct {
 // WfListEntry is a single workflow in the list result.
 type WfListEntry struct {
 	Name        string `json:"name"`
-	Namespace   string `json:"namespace"`
+	Namespace   string `json:"enclave"`
 	Version     string `json:"version"`
 	Description string `json:"description,omitempty"`
 	Owner       string `json:"owner,omitempty"`
@@ -124,7 +124,7 @@ type WfListResult struct {
 
 // WfDescribeParams are the parameters for wf_describe.
 type WfDescribeParams struct {
-	Namespace string `json:"namespace,omitempty" jsonschema:"Namespace of the workflow (auto-resolved if caller belongs to exactly one enclave)"`
+	Namespace string `json:"enclave,omitempty" jsonschema:"Enclave of the workflow (auto-resolved if caller belongs to exactly one enclave)"`
 	Name      string `json:"name" jsonschema:"Workflow name"`
 }
 
@@ -138,7 +138,7 @@ type WfDescribeResult struct {
 	Group         string            `json:"group,omitempty"`
 	Mode          string            `json:"mode,omitempty"`
 	Preset        string            `json:"preset,omitempty"`
-	Namespace     string            `json:"namespace"`
+	Namespace     string            `json:"enclave"`
 	Environment   string            `json:"environment,omitempty"`
 	TriggerType   string            `json:"trigger_type,omitempty"`
 	Name          string            `json:"name"`
@@ -173,7 +173,7 @@ type WfDescribeResult struct {
 func registerDiscoverTools(srv *mcp.Server, client *k8s.Client, eval *authz.Evaluator) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_list",
-		Description: "List all tentacular-managed workflow deployments across namespaces, with ownership and status.",
+		Description: "List all tentacular-managed workflow deployments across enclaves, with ownership and status.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "List Deployed Workflows",
 			ReadOnlyHint:    true,

--- a/pkg/tools/health.go
+++ b/pkg/tools/health.go
@@ -43,12 +43,12 @@ type HealthNodesResult struct {
 
 // HealthNsUsageParams are the parameters for health_ns_usage.
 type HealthNsUsageParams struct {
-	Namespace string `json:"namespace" jsonschema:"Namespace to check resource usage for"`
+	Namespace string `json:"enclave" jsonschema:"Enclave to check resource usage for"`
 }
 
 // HealthNsUsageResult is the result of health_ns_usage.
 type HealthNsUsageResult struct {
-	Namespace string  `json:"namespace"`
+	Namespace string  `json:"enclave"`
 	CPUUsed   string  `json:"cpu_used"`
 	CPULimit  string  `json:"cpu_limit"`
 	MemUsed   string  `json:"mem_used"`
@@ -93,8 +93,8 @@ func registerHealthTools(srv *mcp.Server, client *k8s.Client, eval *authz.Evalua
 	})
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name:        "health_ns_usage",
-		Description: "Compare namespace resource usage against ResourceQuota limits and return utilization percentages.",
+		Name:        "health_enclave_usage",
+		Description: "Compare enclave resource usage against ResourceQuota limits and return utilization percentages.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Namespace Resource Usage",
 			ReadOnlyHint:    true,

--- a/pkg/tools/run.go
+++ b/pkg/tools/run.go
@@ -18,7 +18,7 @@ import (
 
 // WfRunParams are the parameters for wf_run.
 type WfRunParams struct {
-	Namespace string          `json:"namespace" jsonschema:"Namespace of the workflow"`
+	Namespace string          `json:"enclave" jsonschema:"Enclave of the workflow"`
 	Name      string          `json:"name" jsonschema:"Workflow deployment name"`
 	Input     json.RawMessage `json:"input,omitempty" jsonschema:"Optional JSON input payload"`
 	TimeoutS  int             `json:"timeout_seconds,omitempty" jsonschema:"Timeout in seconds (default 120, max 600)"`
@@ -28,7 +28,7 @@ type WfRunParams struct {
 type WfRunResult struct {
 	Output     map[string]any `json:"output"`
 	Name       string         `json:"name"`
-	Namespace  string         `json:"namespace"`
+	Namespace  string         `json:"enclave"`
 	DurationMs int64          `json:"duration_ms"`
 }
 

--- a/pkg/tools/wf_health.go
+++ b/pkg/tools/wf_health.go
@@ -32,7 +32,7 @@ var wfHealthProbe = func(name, namespace string, detail bool) (string, error) {
 
 // WfHealthParams are the parameters for wf_health.
 type WfHealthParams struct {
-	Namespace string `json:"namespace,omitempty" jsonschema:"Workflow namespace (auto-resolved if caller belongs to exactly one enclave)"`
+	Namespace string `json:"enclave,omitempty" jsonschema:"Workflow enclave (auto-resolved if caller belongs to exactly one enclave)"`
 	Name      string `json:"name" jsonschema:"Deployment name"`
 	Detail    bool   `json:"detail,omitempty" jsonschema:"Include execution telemetry from health endpoint (default false)"`
 }
@@ -40,7 +40,7 @@ type WfHealthParams struct {
 // WfHealthResult is the result of wf_health.
 type WfHealthResult struct {
 	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
+	Namespace string `json:"enclave"`
 	Status    string `json:"status"`
 	Reason    string `json:"reason,omitempty"`
 	Detail    string `json:"detail,omitempty"`
@@ -49,7 +49,7 @@ type WfHealthResult struct {
 
 // WfHealthNsParams are the parameters for wf_health_ns.
 type WfHealthNsParams struct {
-	Namespace string `json:"namespace,omitempty" jsonschema:"Namespace to scan (auto-resolved if caller belongs to exactly one enclave)"`
+	Namespace string `json:"enclave,omitempty" jsonschema:"Enclave to scan (auto-resolved if caller belongs to exactly one enclave)"`
 	Limit     int    `json:"limit,omitempty" jsonschema:"Max workflows to check (default 20)"`
 }
 
@@ -69,7 +69,7 @@ type WfHealthNsEntry struct {
 
 // WfHealthNsResult is the result of wf_health_ns.
 type WfHealthNsResult struct {
-	Namespace string            `json:"namespace"`
+	Namespace string            `json:"enclave"`
 	Workflows []WfHealthNsEntry `json:"workflows"`
 	Summary   WfHealthNsSummary `json:"summary"`
 	Total     int               `json:"total"`
@@ -105,8 +105,8 @@ func registerWfHealthTools(srv *mcp.Server, client *k8s.Client, eval *authz.Eval
 	})
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name:        "wf_health_ns",
-		Description: "Aggregate G/A/R health status for all tentacular workflow deployments in a namespace.",
+		Name:        "wf_health_enclave",
+		Description: "Aggregate G/A/R health status for all tentacular workflow deployments in an enclave.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Namespace Workflow Health",
 			ReadOnlyHint:    true,

--- a/pkg/tools/workflow.go
+++ b/pkg/tools/workflow.go
@@ -24,7 +24,7 @@ import (
 
 // WfPodsParams are the parameters for wf_pods.
 type WfPodsParams struct {
-	Namespace string `json:"namespace,omitempty" jsonschema:"Namespace to list pods in (auto-resolved if caller belongs to exactly one enclave)"`
+	Namespace string `json:"enclave,omitempty" jsonschema:"Enclave to list pods in (auto-resolved if caller belongs to exactly one enclave)"`
 }
 
 // WfPodInfo is a single pod in the list result.
@@ -44,7 +44,7 @@ type WfPodsResult struct {
 
 // WfLogsParams are the parameters for wf_logs.
 type WfLogsParams struct {
-	Namespace string `json:"namespace,omitempty" jsonschema:"Namespace of the pod (auto-resolved if caller belongs to exactly one enclave)"`
+	Namespace string `json:"enclave,omitempty" jsonschema:"Enclave of the pod (auto-resolved if caller belongs to exactly one enclave)"`
 	Pod       string `json:"pod" jsonschema:"Name of the pod to get logs from"`
 	Container string `json:"container,omitempty" jsonschema:"Container name (optional, defaults to first container)"`
 	TailLines int64  `json:"tail_lines,omitempty" jsonschema:"Number of log lines to return (default 100)"`
@@ -59,7 +59,7 @@ type WfLogsResult struct {
 
 // WfEventsParams are the parameters for wf_events.
 type WfEventsParams struct {
-	Namespace string `json:"namespace,omitempty" jsonschema:"Namespace to list events in (auto-resolved if caller belongs to exactly one enclave)"`
+	Namespace string `json:"enclave,omitempty" jsonschema:"Enclave to list events in (auto-resolved if caller belongs to exactly one enclave)"`
 	Limit     int64  `json:"limit,omitempty" jsonschema:"Maximum number of events to return (default 100)"`
 }
 
@@ -80,7 +80,7 @@ type WfEventsResult struct {
 
 // WfJobsParams are the parameters for wf_jobs.
 type WfJobsParams struct {
-	Namespace string `json:"namespace,omitempty" jsonschema:"Namespace to list jobs in (auto-resolved if caller belongs to exactly one enclave)"`
+	Namespace string `json:"enclave,omitempty" jsonschema:"Enclave to list jobs in (auto-resolved if caller belongs to exactly one enclave)"`
 }
 
 // WfJobInfo is a single job in the list result.
@@ -109,13 +109,13 @@ type WfJobsResult struct {
 
 // WfRestartParams are the parameters for wf_restart.
 type WfRestartParams struct {
-	Namespace  string `json:"namespace,omitempty" jsonschema:"Namespace containing the deployment (auto-resolved if caller belongs to exactly one enclave)"`
+	Namespace  string `json:"enclave,omitempty" jsonschema:"Enclave containing the deployment (auto-resolved if caller belongs to exactly one enclave)"`
 	Deployment string `json:"deployment" jsonschema:"Name of the deployment to restart"`
 }
 
 // WfRestartResult is the result of wf_restart.
 type WfRestartResult struct {
-	Namespace  string `json:"namespace"`
+	Namespace  string `json:"enclave"`
 	Deployment string `json:"deployment"`
 	Restarted  bool   `json:"restarted"`
 }
@@ -123,7 +123,7 @@ type WfRestartResult struct {
 func registerWorkflowTools(srv *mcp.Server, client *k8s.Client, eval *authz.Evaluator) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_pods",
-		Description: "List pods in a namespace with phase, readiness, restart count, images, and age.",
+		Description: "List pods in an enclave with phase, readiness, restart count, images, and age.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "List Workflow Pods",
 			ReadOnlyHint:    true,
@@ -153,7 +153,7 @@ func registerWorkflowTools(srv *mcp.Server, client *k8s.Client, eval *authz.Eval
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_logs",
-		Description: "Get pod logs from a namespace. Returns tail lines (default 100).",
+		Description: "Get pod logs from an enclave. Returns tail lines (default 100).",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Get Pod Logs",
 			ReadOnlyHint:    true,
@@ -186,7 +186,7 @@ func registerWorkflowTools(srv *mcp.Server, client *k8s.Client, eval *authz.Eval
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_events",
-		Description: "List events in a namespace sorted by most recent first.",
+		Description: "List events in an enclave sorted by most recent first.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "List Namespace Events",
 			ReadOnlyHint:    true,
@@ -216,7 +216,7 @@ func registerWorkflowTools(srv *mcp.Server, client *k8s.Client, eval *authz.Eval
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_jobs",
-		Description: "List Jobs and CronJobs in a namespace.",
+		Description: "List Jobs and CronJobs in an enclave.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "List Jobs and CronJobs",
 			ReadOnlyHint:    true,
@@ -246,7 +246,7 @@ func registerWorkflowTools(srv *mcp.Server, client *k8s.Client, eval *authz.Eval
 
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wf_restart",
-		Description: "Rollout restart a deployment in a managed namespace by patching the pod template with a restart timestamp. Useful after ConfigMap/Secret changes, credential rotation, or gVisor enablement.",
+		Description: "Rollout restart a deployment in a managed enclave by patching the pod template with a restart timestamp. Useful after ConfigMap/Secret changes, credential rotation, or gVisor enablement.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Restart Workflow Deployment",
 			ReadOnlyHint:    false,

--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -157,7 +157,7 @@ func TestE2E_WorkflowPodsEventsJobs(t *testing.T) {
 	})
 
 	// wf_pods - empty namespace, should return empty list.
-	text := callTool(t, session, "wf_pods", map[string]any{"namespace": nsName})
+	text := callTool(t, session, "wf_pods", map[string]any{"enclave": nsName})
 	var podsResult struct {
 		Pods []struct {
 			Name string `json:"name"`
@@ -170,7 +170,7 @@ func TestE2E_WorkflowPodsEventsJobs(t *testing.T) {
 
 	// wf_events
 	text = callTool(t, session, "wf_events", map[string]any{
-		"namespace": nsName,
+		"enclave": nsName,
 		"limit":     10,
 	})
 	var eventsResult struct {
@@ -184,7 +184,7 @@ func TestE2E_WorkflowPodsEventsJobs(t *testing.T) {
 	t.Logf("wf_events: %d events", len(eventsResult.Events))
 
 	// wf_jobs - empty namespace.
-	text = callTool(t, session, "wf_jobs", map[string]any{"namespace": nsName})
+	text = callTool(t, session, "wf_jobs", map[string]any{"enclave": nsName})
 	var jobsResult struct {
 		Jobs     []any `json:"jobs"`
 		CronJobs []any `json:"cronjobs"`
@@ -212,7 +212,7 @@ func TestE2E_ClusterPreflightAndProfile(t *testing.T) {
 	})
 
 	// cluster_preflight
-	text := callTool(t, session, "cluster_preflight", map[string]any{"namespace": nsName})
+	text := callTool(t, session, "enclave_preflight", map[string]any{"enclave": nsName})
 	var preflightResult struct {
 		Checks []struct {
 			Name    string `json:"name"`
@@ -230,7 +230,7 @@ func TestE2E_ClusterPreflightAndProfile(t *testing.T) {
 	}
 
 	// cluster_profile (with namespace)
-	text = callTool(t, session, "cluster_profile", map[string]any{"namespace": nsName})
+	text = callTool(t, session, "cluster_profile", map[string]any{"enclave": nsName})
 	var profileResult struct {
 		K8sVersion   string `json:"k8sVersion"`
 		Distribution string `json:"distribution"`
@@ -241,7 +241,7 @@ func TestE2E_ClusterPreflightAndProfile(t *testing.T) {
 		CNI struct {
 			Name string `json:"name"`
 		} `json:"cni"`
-		Namespace string `json:"namespace"`
+		Namespace string `json:"enclave"`
 		Quota     *struct {
 			CPURequest string `json:"cpuRequest"`
 		} `json:"quota"`
@@ -310,9 +310,9 @@ func TestE2E_HealthNodesUsageSummary(t *testing.T) {
 		"quota_preset": "medium",
 	})
 
-	text = callTool(t, session, "health_ns_usage", map[string]any{"namespace": nsName})
+	text = callTool(t, session, "health_enclave_usage", map[string]any{"enclave": nsName})
 	var usageResult struct {
-		Namespace string  `json:"namespace"`
+		Namespace string  `json:"enclave"`
 		CPULimit  string  `json:"cpu_limit"`
 		MemLimit  string  `json:"mem_limit"`
 		PodLimit  int     `json:"pod_limit"`
@@ -367,7 +367,7 @@ func TestE2E_AuditRbacNetpolPsa(t *testing.T) {
 	})
 
 	// audit_rbac
-	text := callTool(t, session, "audit_rbac", map[string]any{"namespace": nsName})
+	text := callTool(t, session, "audit_rbac", map[string]any{"enclave": nsName})
 	var rbacResult struct {
 		Findings []struct {
 			Role     string `json:"role"`
@@ -381,7 +381,7 @@ func TestE2E_AuditRbacNetpolPsa(t *testing.T) {
 	t.Logf("audit_rbac: %d findings", len(rbacResult.Findings))
 
 	// audit_netpol
-	text = callTool(t, session, "audit_netpol", map[string]any{"namespace": nsName})
+	text = callTool(t, session, "audit_netpol", map[string]any{"enclave": nsName})
 	var netpolResult struct {
 		DefaultDeny bool `json:"default_deny"`
 		Policies    []struct {
@@ -403,7 +403,7 @@ func TestE2E_AuditRbacNetpolPsa(t *testing.T) {
 	}
 
 	// audit_psa
-	text = callTool(t, session, "audit_psa", map[string]any{"namespace": nsName})
+	text = callTool(t, session, "audit_psa", map[string]any{"enclave": nsName})
 	var psaResult struct {
 		Compliant bool   `json:"compliant"`
 		Enforce   string `json:"enforce"`
@@ -448,13 +448,13 @@ func TestE2E_WorkflowApplyStatusRemove(t *testing.T) {
 	}
 
 	text := callTool(t, session, "wf_apply", map[string]any{
-		"namespace": nsName,
+		"enclave": nsName,
 		"name":      "test-app",
 		"manifests": manifests,
 	})
 	var applyResult struct {
 		Name      string `json:"name"`
-		Namespace string `json:"namespace"`
+		Namespace string `json:"enclave"`
 		Created   int    `json:"created"`
 		Updated   int    `json:"updated"`
 		Deleted   int    `json:"deleted"`
@@ -471,7 +471,7 @@ func TestE2E_WorkflowApplyStatusRemove(t *testing.T) {
 
 	// wf_status
 	text = callTool(t, session, "wf_status", map[string]any{
-		"namespace": nsName,
+		"enclave": nsName,
 		"name":      "test-app",
 	})
 	var statusResult struct {
@@ -490,7 +490,7 @@ func TestE2E_WorkflowApplyStatusRemove(t *testing.T) {
 
 	// wf_apply again (update, should be idempotent).
 	text = callTool(t, session, "wf_apply", map[string]any{
-		"namespace": nsName,
+		"enclave": nsName,
 		"name":      "test-app",
 		"manifests": manifests,
 	})
@@ -502,7 +502,7 @@ func TestE2E_WorkflowApplyStatusRemove(t *testing.T) {
 
 	// wf_remove
 	text = callTool(t, session, "wf_remove", map[string]any{
-		"namespace": nsName,
+		"enclave": nsName,
 		"name":      "test-app",
 	})
 	var removeResult struct {

--- a/test/integration/enclave_test.go
+++ b/test/integration/enclave_test.go
@@ -391,7 +391,7 @@ func TestEnclave_MemberPermissions(t *testing.T) {
 		},
 	}
 	text := callTool(t, session, "wf_apply", map[string]any{
-		"namespace": enclaveName,
+		"enclave": enclaveName,
 		"name":      "enc-tentacle",
 		"manifests": manifests,
 	})
@@ -480,7 +480,7 @@ func TestEnclave_DeprovisionCleanup(t *testing.T) {
 		},
 	}
 	callTool(t, session, "wf_apply", map[string]any{
-		"namespace": enclaveName,
+		"enclave": enclaveName,
 		"name":      "cleanup-tentacle",
 		"manifests": manifests,
 	})


### PR DESCRIPTION
## Summary
- Rename all `namespace` JSON tags to `enclave` in tool param structs (19 tools)
- Rename `cluster_preflight` -> `enclave_preflight`
- Rename `wf_health_ns` -> `wf_health_enclave`
- Rename `health_ns_usage` -> `health_enclave_usage`

Part of the cross-repo enclave paradigm changes for v0.9.0. See also:
- randybias/tentacular#TBD (CLI changes)
- randybias/tentacular-skill#TBD (skill docs)
- randybias/tentacular-scaffolds#TBD (api-token rename)
- randybias/thekraken-reference#TBD (old Kraken patch)

## Test plan
- [x] `go test ./pkg/...` - all pass
- [x] `golangci-lint run ./...` - 0 issues
- [ ] E2E test on eastus cluster after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)