### PR TITLE
fix(keycloak): add offline_access as optional scope on tentacular-mcp client

### DIFF
--- a/charts/tentacular-platform/templates/keycloak-realm-configmap.yaml
+++ b/charts/tentacular-platform/templates/keycloak-realm-configmap.yaml
@@ -74,7 +74,8 @@ data:
             "{{ $kcScheme }}://{{ $mcpHost }}/*"
           ],
           "webOrigins": ["+"],
-          "defaultClientScopes": ["openid", "email", "profile"]
+          "defaultClientScopes": ["openid", "email", "profile"],
+          "optionalClientScopes": ["offline_access"]
         },
         {
           "clientId": {{ .Values.keycloak.clients.kraken.clientId | default "thekraken" | quote }},

--- a/docs/keycloak-oidc-clients.md
+++ b/docs/keycloak-oidc-clients.md
@@ -35,12 +35,26 @@ The MCP server is a **resource server**, not an OIDC client. It validates tokens
 | standardFlowEnabled | true | Claude Code uses authorization code + PKCE |
 | directAccessGrantsEnabled | true | tntc CLI can use resource owner password grant |
 | deviceAuth | true | tntc CLI primary flow (device authorization) |
+| defaultClientScopes | `openid`, `email`, `profile` | Baseline identity claims |
+| optionalClientScopes | **`offline_access`** | REQUIRED — see "offline_access requirement" below |
 
 **Consumers:**
 - `tntc` CLI: Device authorization flow (`tntc login` opens browser, polls for token)
 - Claude Code `.mcp.json`: Authorization code + PKCE via OAuth popup (no client secret in config)
 
 **Why public:** Both consumers run on a developer's machine. A CLI binary and a browser-based OAuth popup cannot securely store a client secret. PKCE provides equivalent security for public clients.
+
+#### `offline_access` requirement
+
+The `tentacular-mcp` client **must** list `offline_access` under `optionalClientScopes`. This is not optional despite the field name — Claude Code will refuse to connect without it.
+
+**Why:** Claude Code (verified on 2.1.112) unconditionally appends `offline_access` to the authorization request whenever the auth server's discovery metadata advertises the scope in `scopes_supported`. Keycloak advertises it by default, and the append happens inside Claude Code's scope-resolution code AFTER any `oauth.scopes` override in `.mcp.json`, so the behavior cannot be worked around on the client side.
+
+If the scope is not listed on the client, Keycloak rejects the authorization request with `invalid_scope: Invalid scopes: openid email profile offline_access` and the OAuth flow dies before reaching the callback.
+
+Listing it as **optional** (not default) means the scope is only included in tokens when a consumer explicitly requests it — we do not want every access token to carry a refresh-token side channel for consumers that don't need one.
+
+This does NOT apply to `thekraken` (device grant, does not request `offline_access`) or `chroma` (NextAuth server-side, manages its own scope set).
 
 ### thekraken (CONFIDENTIAL)
 
@@ -86,6 +100,9 @@ Keycloak uses **PostgreSQL** for persistent storage. The realm import ConfigMap 
 
 ### "Invalid client or Invalid client credentials"
 The client is configured as confidential but the consumer is trying a public flow (no secret). Check `publicClient` on the Keycloak client. For `tentacular-mcp`, this MUST be `true`.
+
+### "invalid_scope: Invalid scopes: openid email profile offline_access"
+Claude Code requested `offline_access` but the `tentacular-mcp` client does not list it. Add `offline_access` under `optionalClientScopes` on the client. See the "offline_access requirement" section above for the full explanation. This is NOT optional for `tentacular-mcp` — Claude Code cannot be configured to skip the scope.
 
 ### "Invalid refresh token" / token expiry
 Token lifespans are set at the realm level:

--- a/docs/keycloak-oidc-clients.md
+++ b/docs/keycloak-oidc-clients.md
@@ -52,7 +52,7 @@ The `tentacular-mcp` client **must** list `offline_access` under `optionalClient
 
 If the scope is not listed on the client, Keycloak rejects the authorization request with `invalid_scope: Invalid scopes: openid email profile offline_access` and the OAuth flow dies before reaching the callback.
 
-Listing it as **optional** (not default) means the scope is only included in tokens when a consumer explicitly requests it — we do not want every access token to carry a refresh-token side channel for consumers that don't need one.
+Listing it as **optional** (not default) means Keycloak only issues a refresh token / offline token when a consumer explicitly requests the scope. We don't want to hand every caller long-lived refresh machinery if they didn't ask for it.
 
 This does NOT apply to `thekraken` (device grant, does not request `offline_access`) or `chroma` (NextAuth server-side, manages its own scope set).
 
@@ -103,6 +103,8 @@ The client is configured as confidential but the consumer is trying a public flo
 
 ### "invalid_scope: Invalid scopes: openid email profile offline_access"
 Claude Code requested `offline_access` but the `tentacular-mcp` client does not list it. Add `offline_access` under `optionalClientScopes` on the client. See the "offline_access requirement" section above for the full explanation. This is NOT optional for `tentacular-mcp` — Claude Code cannot be configured to skip the scope.
+
+**On a running cluster, also patch live.** The realm ConfigMap is seed-only (see Persistence Model), so editing the Helm template does not update a cluster whose realm already exists in Postgres. Apply the change via `kcadm.sh update clients/$CID/optional-client-scopes/$SCOPE_ID -r tentacular -n` inside the Keycloak pod, or via the admin console. The ConfigMap edit prevents regression on the next DB wipe; the live patch fixes the running cluster.
 
 ### "Invalid refresh token" / token expiry
 Token lifespans are set at the realm level:


### PR DESCRIPTION
## Summary
- Adds `offline_access` to `optionalClientScopes` on the `tentacular-mcp` Keycloak client
- Documents the requirement in `docs/keycloak-oidc-clients.md`
- Unblocks Claude Code `/mcp` OAuth reconnect after a Keycloak realm rebuild

## Why this is required
Claude Code (verified on 2.1.112) unconditionally appends `offline_access` to authorization requests when the auth server advertises the scope in `scopes_supported`. The behavior is hardcoded in the client binary and cannot be worked around via `.mcp.json` `oauth.scopes` pin. Without the scope listed on the client, Keycloak rejects the request with `invalid_scope` and the OAuth flow dies.

Listing it as **optional** (not default) means consumers only receive refresh tokens when they explicitly request the scope -- we don't want every access token carrying a refresh-token side channel.

Does not affect `thekraken` (device grant, does not request `offline_access`) or `chroma` (NextAuth server-side auth-code, manages its own scopes).

## Live state
Fix applied on eastus 2026-04-17 via `kcadm.sh` -- Postgres is authoritative for the existing realm, so the ConfigMap change only affects fresh installs. This PR lands the seed-file change so future installs match.

## Test plan
- [x] `helm lint charts/tentacular-platform` passes (pre-existing warnings are expected)
- [x] `helm template` renders `optionalClientScopes` on only the `tentacular-mcp` client
- [x] `go test ./pkg/...` still passes (unchanged -- chart-only change)