### PR TITLE
feat(chart): expose exoskeletonAuth.trustedAZPs

### DIFF
--- a/charts/tentacular-platform/templates/exoskeleton-secret.yaml
+++ b/charts/tentacular-platform/templates/exoskeleton-secret.yaml
@@ -120,6 +120,9 @@ stringData:
   TENTACULAR_KEYCLOAK_ISSUER: {{ required "exoskeletonAuth.issuerURL is required when exoskeletonAuth is enabled and keycloak is disabled. Either enable keycloak or set exoskeletonAuth.issuerURL explicitly." $issuerURL | quote }}
   TENTACULAR_KEYCLOAK_CLIENT_ID: {{ .Values.exoskeletonAuth.clientID | default "tentacular-mcp" | quote }}
   TENTACULAR_KEYCLOAK_CLIENT_SECRET: {{ required "exoskeletonAuth.clientSecret is required when exoskeletonAuth is enabled." .Values.exoskeletonAuth.clientSecret | quote }}
+  {{- if .Values.exoskeletonAuth.trustedAZPs }}
+  TENTACULAR_KEYCLOAK_TRUSTED_AZPS: {{ .Values.exoskeletonAuth.trustedAZPs | quote }}
+  {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tentacular-platform/values.yaml
+++ b/charts/tentacular-platform/values.yaml
@@ -224,6 +224,10 @@ exoskeletonAuth:
   clientID: ""
   # -- OIDC client secret
   clientSecret: ""
+  # -- Additional OIDC client IDs whose tokens the MCP server will accept.
+  # The clientID above is always trusted. Add other clients (e.g. "thekraken")
+  # as a comma-separated list when multiple services share the same Keycloak realm.
+  trustedAZPs: ""
 
 # -- esm-sh module proxy configuration
 esm-sh:


### PR DESCRIPTION
## Summary

The MCP server already implements trusted Authorized Parties handling (`pkg/exoskeleton/config.go:86`, `auth.go:17,35`) via the `TENTACULAR_KEYCLOAK_TRUSTED_AZPS` env var. This PR surfaces the setting through the Helm chart so deployers can configure it.

## Why

When thekraken shares a Keycloak realm with the MCP server (and uses a different OIDC client ID), the MCP server needs to accept tokens whose \`azp\` claim matches the Kraken's client ID. Without a chart value, the only way to set this was to manually edit the secret post-install.

## Changes

- \`values.yaml\`: new \`exoskeletonAuth.trustedAZPs\` (default empty)
- \`templates/exoskeleton-secret.yaml\`: conditionally set the env var when non-empty

## Test plan

- [ ] CI green (helm lint)
- [ ] No behavior change when value left empty (default)
- [ ] When set, env var appears in MCP server pod