### PR TITLE
feat(wf_apply): add PSA validation before API server apply

### DIFF
--- a/pkg/k8s/psa.go
+++ b/pkg/k8s/psa.go
@@ -1,0 +1,229 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	// PSA label keys on the namespace.
+	PSAEnforceLabel        = "pod-security.kubernetes.io/enforce"
+	PSAEnforceVersionLabel = "pod-security.kubernetes.io/enforce-version"
+
+	// PSA policy levels.
+	PSALevelPrivileged = "privileged"
+	PSALevelBaseline   = "baseline"
+	PSALevelRestricted = "restricted"
+)
+
+// PSAViolation describes a single PSA requirement that is not met by a manifest.
+type PSAViolation struct {
+	// ManifestKind is the Kubernetes Kind of the violating manifest.
+	ManifestKind string
+	// ManifestName is the metadata.name of the violating manifest.
+	ManifestName string
+	// Field is the spec path that is missing or incorrect.
+	Field string
+	// Reason is a human-readable explanation of the requirement.
+	Reason string
+}
+
+func (v PSAViolation) String() string {
+	return v.ManifestKind + "/" + v.ManifestName + ": " + v.Field + " — " + v.Reason
+}
+
+// PSAValidationError is returned when one or more PSA violations are found.
+// It carries a structured list so callers can surface each issue separately.
+type PSAValidationError struct {
+	Namespace  string
+	Level      string
+	Violations []PSAViolation
+}
+
+func (e *PSAValidationError) Error() string {
+	msgs := make([]string, 0, len(e.Violations)+1)
+	msgs = append(msgs, fmt.Sprintf(
+		"PSA validation failed for namespace %q (enforce=%s): %d violation(s)",
+		e.Namespace, e.Level, len(e.Violations),
+	))
+	for _, v := range e.Violations {
+		msgs = append(msgs, "  - "+v.String())
+	}
+	return strings.Join(msgs, "\n")
+}
+
+// NamespacePSALevel fetches the PSA enforce level for the given namespace.
+// Returns PSALevelPrivileged when the enforce label is absent (permissive default).
+func NamespacePSALevel(ctx context.Context, client *Client, namespace string) (string, error) {
+	ns, err := client.Clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get namespace %q for PSA level: %w", namespace, err)
+	}
+	level, ok := ns.Labels[PSAEnforceLabel]
+	if !ok || level == "" {
+		return PSALevelPrivileged, nil
+	}
+	return level, nil
+}
+
+// ValidatePSA checks whether the provided manifests satisfy the given PSA
+// enforce level. Only Deployment, Job, and CronJob manifests are inspected —
+// other kinds are skipped.
+//
+// For "restricted" level the following are required per container and/or pod:
+//   - pod or container securityContext.runAsNonRoot: true
+//   - container securityContext.allowPrivilegeEscalation: false
+//   - container securityContext.capabilities.drop contains "ALL"
+//   - pod or container securityContext.seccompProfile.type set to
+//     "RuntimeDefault" or "Localhost"
+//
+// NOTE: Image Config.User inspection is intentionally skipped — callers must
+// set explicit runAsNonRoot in the spec. YAGNI: image-inspect can be added
+// later if needed.
+//
+// Returns nil when the level is "privileged" (skip validation).
+// Returns *PSAValidationError listing every failing field when violations exist.
+func ValidatePSA(namespace, level string, manifests []map[string]any) error {
+	if level == "" || level == PSALevelPrivileged {
+		return nil
+	}
+
+	var violations []PSAViolation
+
+	for _, m := range manifests {
+		obj := &unstructured.Unstructured{Object: m}
+		kind := obj.GetKind()
+		name := obj.GetName()
+
+		var podSpecPath []string
+		switch kind {
+		case "Deployment", "Job":
+			podSpecPath = []string{"spec", "template", "spec"}
+		case "CronJob":
+			podSpecPath = []string{"spec", "jobTemplate", "spec", "template", "spec"}
+		default:
+			continue
+		}
+
+		vs := validatePodSpec(obj.Object, podSpecPath, kind, name)
+		violations = append(violations, vs...)
+	}
+
+	if len(violations) > 0 {
+		return &PSAValidationError{
+			Namespace:  namespace,
+			Level:      level,
+			Violations: violations,
+		}
+	}
+	return nil
+}
+
+// validatePodSpec checks the pod-level and container-level security contexts for
+// a workload manifest. The podSpecPath is the dot-path to the PodSpec within the
+// object (e.g., ["spec","template","spec"] for Deployments).
+func validatePodSpec(obj map[string]any, podSpecPath []string, kind, name string) []PSAViolation {
+	var violations []PSAViolation
+
+	scPath := append(append([]string{}, podSpecPath...), "securityContext")
+
+	// ---- Pod-level checks (restricted) ----
+
+	// runAsNonRoot: must be true at pod level OR on every container.
+	// We check pod-level here; container-level is checked per-container below.
+	podRunAsNonRoot, podRunAsNonRootFound, _ := unstructured.NestedBool(obj, append(append([]string{}, scPath...), "runAsNonRoot")...)
+
+	// seccompProfile: must be set at pod OR container level.
+	podSeccompType, podSeccompFound, _ := unstructured.NestedString(obj, append(append([]string{}, scPath...), "seccompProfile", "type")...)
+	podSeccompOK := podSeccompFound && isValidSeccompType(podSeccompType)
+
+	// ---- Container-level checks ----
+	for _, field := range []string{"containers", "initContainers"} {
+		containersRaw, found, _ := unstructured.NestedSlice(obj, append(append([]string{}, podSpecPath...), field)...)
+		if !found {
+			continue
+		}
+
+		for i, cRaw := range containersRaw {
+			c, ok := cRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			containerName := fmt.Sprintf("%s[%d]", field, i)
+			if n, nok, _ := unstructured.NestedString(c, "name"); nok && n != "" {
+				containerName = n
+			}
+
+			qualifier := fmt.Sprintf("%s/%s container %q", kind, name, containerName)
+
+			// runAsNonRoot: required at pod OR container level.
+			cRunAsNonRoot, cRunAsNonRootFound, _ := unstructured.NestedBool(c, "securityContext", "runAsNonRoot")
+			podSatisfied := podRunAsNonRootFound && podRunAsNonRoot
+			containerSatisfied := cRunAsNonRootFound && cRunAsNonRoot
+			if !podSatisfied && !containerSatisfied {
+				violations = append(violations, PSAViolation{
+					ManifestKind: kind,
+					ManifestName: name,
+					Field:        "securityContext.runAsNonRoot",
+					Reason:       qualifier + ": runAsNonRoot must be true at pod or container level (restricted PSA)",
+				})
+			}
+
+			// allowPrivilegeEscalation: must be false at container level.
+			ape, apeFound, _ := unstructured.NestedBool(c, "securityContext", "allowPrivilegeEscalation")
+			if !apeFound || ape {
+				violations = append(violations, PSAViolation{
+					ManifestKind: kind,
+					ManifestName: name,
+					Field:        "securityContext.allowPrivilegeEscalation",
+					Reason:       qualifier + ": allowPrivilegeEscalation must be false (restricted PSA)",
+				})
+			}
+
+			// capabilities.drop: must include ALL.
+			drop, dropFound, _ := unstructured.NestedStringSlice(c, "securityContext", "capabilities", "drop")
+			if !dropFound || !containsALL(drop) {
+				violations = append(violations, PSAViolation{
+					ManifestKind: kind,
+					ManifestName: name,
+					Field:        "securityContext.capabilities.drop",
+					Reason:       qualifier + ": capabilities.drop must contain \"ALL\" (restricted PSA)",
+				})
+			}
+
+			// seccompProfile: must be set at pod OR container level.
+			cSeccompType, cSeccompFound, _ := unstructured.NestedString(c, "securityContext", "seccompProfile", "type")
+			cSeccompOK := cSeccompFound && isValidSeccompType(cSeccompType)
+			if !podSeccompOK && !cSeccompOK {
+				violations = append(violations, PSAViolation{
+					ManifestKind: kind,
+					ManifestName: name,
+					Field:        "securityContext.seccompProfile.type",
+					Reason:       qualifier + ": seccompProfile.type must be RuntimeDefault or Localhost at pod or container level (restricted PSA)",
+				})
+			}
+		}
+	}
+
+	return violations
+}
+
+// isValidSeccompType returns true for the two PSA-allowed seccomp types.
+func isValidSeccompType(t string) bool {
+	return t == "RuntimeDefault" || t == "Localhost"
+}
+
+// containsALL returns true when "ALL" appears in the capabilities drop list.
+func containsALL(drop []string) bool {
+	for _, d := range drop {
+		if strings.EqualFold(d, "ALL") {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/k8s/psa_test.go
+++ b/pkg/k8s/psa_test.go
@@ -1,0 +1,477 @@
+package k8s_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/randybias/tentacular-mcp/pkg/k8s"
+)
+
+// hardenedDeployment returns a manifest that fully satisfies the restricted
+// PSA policy at both pod and container level.
+func hardenedDeployment(name string) map[string]any {
+	return map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": name},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"securityContext": map[string]any{
+						"runAsNonRoot": true,
+						"seccompProfile": map[string]any{
+							"type": "RuntimeDefault",
+						},
+					},
+					"containers": []any{
+						map[string]any{
+							"name":  "app",
+							"image": "myimg:v1",
+							"securityContext": map[string]any{
+								"allowPrivilegeEscalation": false,
+								"runAsNonRoot":             true,
+								"capabilities": map[string]any{
+									"drop": []any{"ALL"},
+								},
+								"seccompProfile": map[string]any{
+									"type": "RuntimeDefault",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestValidatePSA_PrivilegedLevelSkipsValidation verifies that privileged
+// namespaces skip all validation regardless of spec content.
+func TestValidatePSA_PrivilegedLevelSkipsValidation(t *testing.T) {
+	// Missing all security fields — should still pass for privileged.
+	bareDeployment := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "bare"},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{"name": "app", "image": "myimg:v1"},
+					},
+				},
+			},
+		},
+	}
+	for _, level := range []string{"", k8s.PSALevelPrivileged} {
+		if err := k8s.ValidatePSA("ns", level, []map[string]any{bareDeployment}); err != nil {
+			t.Errorf("level=%q: expected nil for privileged namespace, got: %v", level, err)
+		}
+	}
+}
+
+// TestValidatePSA_NonWorkloadKindsSkipped verifies that ConfigMap, Service, and
+// other non-workload kinds are silently skipped during PSA validation.
+func TestValidatePSA_NonWorkloadKindsSkipped(t *testing.T) {
+	cm := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "my-cm"},
+		"data":       map[string]any{"key": "val"},
+	}
+	svc := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata":   map[string]any{"name": "my-svc"},
+	}
+	if err := k8s.ValidatePSA("ns", k8s.PSALevelRestricted, []map[string]any{cm, svc}); err != nil {
+		t.Errorf("expected nil for non-workload kinds, got: %v", err)
+	}
+}
+
+// TestValidatePSA_HardenedSpecPassesRestricted verifies that a fully-hardened
+// Deployment passes restricted PSA validation.
+func TestValidatePSA_HardenedSpecPassesRestricted(t *testing.T) {
+	manifests := []map[string]any{hardenedDeployment("hardened-app")}
+	if err := k8s.ValidatePSA("my-ns", k8s.PSALevelRestricted, manifests); err != nil {
+		t.Errorf("expected nil for hardened spec, got: %v", err)
+	}
+}
+
+// TestValidatePSA_MissingRunAsNonRoot fails when neither pod nor container has
+// runAsNonRoot: true.
+func TestValidatePSA_MissingRunAsNonRoot(t *testing.T) {
+	m := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "no-runasnonroot"},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"securityContext": map[string]any{
+						"seccompProfile": map[string]any{"type": "RuntimeDefault"},
+					},
+					"containers": []any{
+						map[string]any{
+							"name":  "app",
+							"image": "myimg:v1",
+							"securityContext": map[string]any{
+								"allowPrivilegeEscalation": false,
+								"capabilities":             map[string]any{"drop": []any{"ALL"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	err := k8s.ValidatePSA("ns", k8s.PSALevelRestricted, []map[string]any{m})
+	if err == nil {
+		t.Fatal("expected error for missing runAsNonRoot, got nil")
+	}
+	if !strings.Contains(err.Error(), "runAsNonRoot") {
+		t.Errorf("error should mention runAsNonRoot, got: %v", err)
+	}
+	var psaErr *k8s.PSAValidationError
+	if !errors.As(err, &psaErr) {
+		t.Fatalf("expected *PSAValidationError, got %T", err)
+	}
+	if !hasViolationField(psaErr, "securityContext.runAsNonRoot") {
+		t.Errorf("violations should include securityContext.runAsNonRoot, got: %+v", psaErr.Violations)
+	}
+}
+
+// TestValidatePSA_MissingSeccompProfile fails when neither pod nor container
+// has a seccompProfile set.
+func TestValidatePSA_MissingSeccompProfile(t *testing.T) {
+	m := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "no-seccomp"},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"securityContext": map[string]any{
+						"runAsNonRoot": true,
+						// seccompProfile deliberately absent
+					},
+					"containers": []any{
+						map[string]any{
+							"name":  "app",
+							"image": "myimg:v1",
+							"securityContext": map[string]any{
+								"allowPrivilegeEscalation": false,
+								"runAsNonRoot":             true,
+								"capabilities":             map[string]any{"drop": []any{"ALL"}},
+								// seccompProfile deliberately absent
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	err := k8s.ValidatePSA("ns", k8s.PSALevelRestricted, []map[string]any{m})
+	if err == nil {
+		t.Fatal("expected error for missing seccompProfile, got nil")
+	}
+	var psaErr *k8s.PSAValidationError
+	if !errors.As(err, &psaErr) {
+		t.Fatalf("expected *PSAValidationError, got %T", err)
+	}
+	if !hasViolationField(psaErr, "securityContext.seccompProfile.type") {
+		t.Errorf("violations should include seccompProfile.type, got: %+v", psaErr.Violations)
+	}
+}
+
+// TestValidatePSA_MissingCapabilitiesDrop fails when capabilities.drop does
+// not include ALL.
+func TestValidatePSA_MissingCapabilitiesDrop(t *testing.T) {
+	m := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "no-caps-drop"},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"securityContext": map[string]any{
+						"runAsNonRoot":   true,
+						"seccompProfile": map[string]any{"type": "RuntimeDefault"},
+					},
+					"containers": []any{
+						map[string]any{
+							"name":  "app",
+							"image": "myimg:v1",
+							"securityContext": map[string]any{
+								"allowPrivilegeEscalation": false,
+								"runAsNonRoot":             true,
+								// capabilities.drop deliberately absent
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	err := k8s.ValidatePSA("ns", k8s.PSALevelRestricted, []map[string]any{m})
+	if err == nil {
+		t.Fatal("expected error for missing capabilities.drop, got nil")
+	}
+	var psaErr *k8s.PSAValidationError
+	if !errors.As(err, &psaErr) {
+		t.Fatalf("expected *PSAValidationError, got %T", err)
+	}
+	if !hasViolationField(psaErr, "securityContext.capabilities.drop") {
+		t.Errorf("violations should include capabilities.drop, got: %+v", psaErr.Violations)
+	}
+}
+
+// TestValidatePSA_MissingAllowPrivilegeEscalation fails when
+// allowPrivilegeEscalation is not explicitly set to false.
+func TestValidatePSA_MissingAllowPrivilegeEscalation(t *testing.T) {
+	m := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "no-ape"},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"securityContext": map[string]any{
+						"runAsNonRoot":   true,
+						"seccompProfile": map[string]any{"type": "RuntimeDefault"},
+					},
+					"containers": []any{
+						map[string]any{
+							"name":  "app",
+							"image": "myimg:v1",
+							"securityContext": map[string]any{
+								// allowPrivilegeEscalation deliberately absent
+								"runAsNonRoot": true,
+								"capabilities": map[string]any{"drop": []any{"ALL"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	err := k8s.ValidatePSA("ns", k8s.PSALevelRestricted, []map[string]any{m})
+	if err == nil {
+		t.Fatal("expected error for missing allowPrivilegeEscalation, got nil")
+	}
+	var psaErr *k8s.PSAValidationError
+	if !errors.As(err, &psaErr) {
+		t.Fatalf("expected *PSAValidationError, got %T", err)
+	}
+	if !hasViolationField(psaErr, "securityContext.allowPrivilegeEscalation") {
+		t.Errorf("violations should include allowPrivilegeEscalation, got: %+v", psaErr.Violations)
+	}
+}
+
+// TestValidatePSA_BaselineSpecFailsRestricted verifies that a spec that satisfies
+// "baseline" PSA (i.e., no privileged containers, host namespaces) but is missing
+// restricted-only fields (runAsNonRoot, seccomp, etc.) fails restricted validation.
+func TestValidatePSA_BaselineSpecFailsRestricted(t *testing.T) {
+	// Baseline allows this (no privileged flag, no host networking), but
+	// restricted requires runAsNonRoot, seccompProfile, allowPrivilegeEscalation=false,
+	// and capabilities.drop=ALL.
+	baselineOnly := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "baseline-spec"},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":  "app",
+							"image": "myimg:v1",
+							// No securityContext at all — baseline would allow this
+							// but restricted requires all the fields below.
+						},
+					},
+				},
+			},
+		},
+	}
+	err := k8s.ValidatePSA("ns", k8s.PSALevelRestricted, []map[string]any{baselineOnly})
+	if err == nil {
+		t.Fatal("expected error: baseline spec should fail restricted validation")
+	}
+	var psaErr *k8s.PSAValidationError
+	if !errors.As(err, &psaErr) {
+		t.Fatalf("expected *PSAValidationError, got %T", err)
+	}
+	// Should have multiple violations — all four restricted fields missing.
+	if len(psaErr.Violations) < 3 {
+		t.Errorf("expected at least 3 violations for bare spec, got %d: %v", len(psaErr.Violations), psaErr.Violations)
+	}
+}
+
+// TestValidatePSA_ErrorListsEachFieldSeparately verifies that the structured
+// error enumerates each missing field as a separate violation entry.
+func TestValidatePSA_ErrorListsEachFieldSeparately(t *testing.T) {
+	bare := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "bare"},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{"name": "app", "image": "myimg:v1"},
+					},
+				},
+			},
+		},
+	}
+	err := k8s.ValidatePSA("ns", k8s.PSALevelRestricted, []map[string]any{bare})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var psaErr *k8s.PSAValidationError
+	if !errors.As(err, &psaErr) {
+		t.Fatalf("expected *PSAValidationError")
+	}
+	// Verify specific fields are reported separately.
+	fields := make(map[string]bool, len(psaErr.Violations))
+	for _, v := range psaErr.Violations {
+		fields[v.Field] = true
+	}
+	wantFields := []string{
+		"securityContext.runAsNonRoot",
+		"securityContext.allowPrivilegeEscalation",
+		"securityContext.capabilities.drop",
+		"securityContext.seccompProfile.type",
+	}
+	for _, f := range wantFields {
+		if !fields[f] {
+			t.Errorf("expected violation for field %q, not found in: %v", f, psaErr.Violations)
+		}
+	}
+}
+
+// TestValidatePSA_JobManifest verifies that Job manifests are also validated.
+func TestValidatePSA_JobManifest(t *testing.T) {
+	job := map[string]any{
+		"apiVersion": "batch/v1",
+		"kind":       "Job",
+		"metadata":   map[string]any{"name": "bare-job"},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{"name": "worker", "image": "busybox:latest"},
+					},
+				},
+			},
+		},
+	}
+	err := k8s.ValidatePSA("ns", k8s.PSALevelRestricted, []map[string]any{job})
+	if err == nil {
+		t.Fatal("expected error for bare Job, got nil")
+	}
+	if !strings.Contains(err.Error(), "Job") {
+		t.Errorf("error should mention Job kind, got: %v", err)
+	}
+}
+
+// TestValidatePSA_SeccompAtPodLevelSatisfiesContainerRequirement verifies that
+// a seccompProfile set at the pod level satisfies the requirement for all containers
+// (no need to duplicate it on each container).
+func TestValidatePSA_SeccompAtPodLevelSatisfiesContainerRequirement(t *testing.T) {
+	m := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "pod-level-seccomp"},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"securityContext": map[string]any{
+						"runAsNonRoot":   true,
+						"seccompProfile": map[string]any{"type": "RuntimeDefault"}, // pod-level
+					},
+					"containers": []any{
+						map[string]any{
+							"name":  "app",
+							"image": "myimg:v1",
+							"securityContext": map[string]any{
+								"allowPrivilegeEscalation": false,
+								"runAsNonRoot":             true,
+								"capabilities":             map[string]any{"drop": []any{"ALL"}},
+								// seccompProfile absent at container level — pod level should satisfy
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := k8s.ValidatePSA("ns", k8s.PSALevelRestricted, []map[string]any{m}); err != nil {
+		t.Errorf("expected nil when seccompProfile is at pod level, got: %v", err)
+	}
+}
+
+// TestValidatePSA_RunAsNonRootAtPodLevelSatisfiesContainerRequirement verifies
+// that runAsNonRoot at pod level satisfies the requirement for all containers.
+func TestValidatePSA_RunAsNonRootAtPodLevelSatisfiesContainerRequirement(t *testing.T) {
+	m := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "pod-level-nonroot"},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"securityContext": map[string]any{
+						"runAsNonRoot":   true, // pod-level
+						"seccompProfile": map[string]any{"type": "RuntimeDefault"},
+					},
+					"containers": []any{
+						map[string]any{
+							"name":  "app",
+							"image": "myimg:v1",
+							"securityContext": map[string]any{
+								"allowPrivilegeEscalation": false,
+								// runAsNonRoot absent at container level
+								"capabilities": map[string]any{"drop": []any{"ALL"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := k8s.ValidatePSA("ns", k8s.PSALevelRestricted, []map[string]any{m}); err != nil {
+		t.Errorf("expected nil when runAsNonRoot is at pod level, got: %v", err)
+	}
+}
+
+// TestPSAValidationError_Format verifies that PSAValidationError.Error() includes
+// the namespace, level, and each violation.
+func TestPSAValidationError_Format(t *testing.T) {
+	err := &k8s.PSAValidationError{
+		Namespace: "my-ns",
+		Level:     "restricted",
+		Violations: []k8s.PSAViolation{
+			{ManifestKind: "Deployment", ManifestName: "my-app", Field: "securityContext.runAsNonRoot", Reason: "must be true"},
+		},
+	}
+	msg := err.Error()
+	for _, want := range []string{"my-ns", "restricted", "securityContext.runAsNonRoot"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %v", want, msg)
+		}
+	}
+}
+
+// hasViolationField is a helper that checks whether any violation in a
+// PSAValidationError matches the given field path.
+func hasViolationField(err *k8s.PSAValidationError, field string) bool {
+	for _, v := range err.Violations {
+		if v.Field == field {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/tools/deploy.go
+++ b/pkg/tools/deploy.go
@@ -515,6 +515,19 @@ func handleWorkflowApply(ctx context.Context, client *k8s.Client, params Workflo
 	// Ensure all workload manifests have PSA-compliant security contexts.
 	ensurePSACompliance(params.Manifests)
 
+	// Validate the (post-compliance) manifests against the namespace's PSA
+	// enforce policy before touching the API server. This catches hand-rolled
+	// specs that bypass tntc deploy and would be rejected by admission, giving
+	// the caller a structured error instead of a 60-second timeout + misleading
+	// "Deployed" message.
+	psaLevel, psaErr := k8s.NamespacePSALevel(ctx, client, params.Namespace)
+	if psaErr != nil {
+		return WorkflowApplyResult{}, psaErr
+	}
+	if err := k8s.ValidatePSA(params.Namespace, psaLevel, params.Manifests); err != nil {
+		return WorkflowApplyResult{}, err
+	}
+
 	created, updated, deleted := 0, 0, 0
 	appliedKeys := make(map[string]bool)
 

--- a/pkg/tools/deploy_psa_test.go
+++ b/pkg/tools/deploy_psa_test.go
@@ -1,0 +1,287 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+
+	"github.com/randybias/tentacular-mcp/pkg/k8s"
+)
+
+// restrictedNs returns a namespace with PSA enforce=restricted labels and the
+// tentacular managed-by label.
+func restrictedNs(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				k8s.ManagedByLabel:                           k8s.ManagedByValue,
+				"pod-security.kubernetes.io/enforce":         "restricted",
+				"pod-security.kubernetes.io/enforce-version": "latest",
+			},
+		},
+	}
+}
+
+// privilegedNs returns a namespace with no PSA enforce label (privileged default).
+func privilegedNs(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				k8s.ManagedByLabel: k8s.ManagedByValue,
+			},
+		},
+	}
+}
+
+// newPSATestClient returns a test client seeded with the given namespaces.
+// Discovery is pre-populated so resolveGVR can find apps/v1 and core v1 kinds.
+func newPSATestClient(namespaces ...*corev1.Namespace) *k8s.Client {
+	scheme := deployScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, deployGVRs)
+	objs := make([]runtime.Object, 0, len(namespaces))
+	for _, ns := range namespaces {
+		objs = append(objs, ns)
+	}
+	staticClient := kubefake.NewClientset(objs...)
+	// Inject discovery resource lists so resolveGVR can resolve all used kinds.
+	staticClient.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Kind: "Deployment", Namespaced: true},
+			},
+		},
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Kind: "ConfigMap", Namespaced: true},
+				{Name: "services", Kind: "Service", Namespaced: true},
+				{Name: "secrets", Kind: "Secret", Namespaced: true},
+			},
+		},
+	}
+	return &k8s.Client{
+		Clientset: staticClient,
+		Dynamic:   dynClient,
+		Config:    &rest.Config{Host: "https://test-cluster:6443"},
+	}
+}
+
+// hardenedDeployManifest returns a wf_apply-style manifest map for a Deployment
+// that fully satisfies restricted PSA after ensurePSACompliance has run.
+func hardenedDeployManifest(name string) map[string]any {
+	return map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": name},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"securityContext": map[string]any{
+						"runAsNonRoot":   true,
+						"seccompProfile": map[string]any{"type": "RuntimeDefault"},
+					},
+					"containers": []any{
+						map[string]any{
+							"name":  "app",
+							"image": "myimg:v1",
+							"securityContext": map[string]any{
+								"allowPrivilegeEscalation": false,
+								"runAsNonRoot":             true,
+								"capabilities":             map[string]any{"drop": []any{"ALL"}},
+								"seccompProfile":           map[string]any{"type": "RuntimeDefault"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// bareDeployManifest returns a wf_apply-style Deployment with no security context.
+// After ensurePSACompliance it will have runAsNonRoot, seccomp, etc. injected —
+// but NOT allowPrivilegeEscalation or capabilities.drop which require explicit values
+// that ensurePSACompliance injects. This is used to test that the fully-injected
+// spec passes PSA validation (since ensurePSACompliance runs before ValidatePSA).
+func bareDeployManifest(name string) map[string]any {
+	return map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": name},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":  "app",
+							"image": "myimg:v1",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// incompleteDeployManifest returns a Deployment with partial security context —
+// runAsNonRoot set but missing allowPrivilegeEscalation and capabilities.drop.
+// Even after ensurePSACompliance (which only sets-if-absent) this spec needs
+// the user-absent fields filled in. ensurePSACompliance will fill them, so to
+// test a truly failing spec we need one where ensurePSACompliance can't fix it.
+//
+// We craft a spec where allowPrivilegeEscalation=true (explicitly) which
+// ensurePSACompliance will NOT overwrite (setIfAbsent leaves it).
+func nonCompliantDeployManifest(name string) map[string]any {
+	return map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": name},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"securityContext": map[string]any{
+						"runAsNonRoot":   true,
+						"seccompProfile": map[string]any{"type": "RuntimeDefault"},
+					},
+					"containers": []any{
+						map[string]any{
+							"name":  "app",
+							"image": "myimg:v1",
+							"securityContext": map[string]any{
+								// allowPrivilegeEscalation explicitly set to true —
+								// ensurePSACompliance won't overwrite this.
+								"allowPrivilegeEscalation": true,
+								"runAsNonRoot":             true,
+								"capabilities":             map[string]any{"drop": []any{"ALL"}},
+								"seccompProfile":           map[string]any{"type": "RuntimeDefault"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestHandleWorkflowApply_HardenedSpecPassesRestrictedNs verifies that a hardened
+// Deployment spec is accepted by wf_apply when the namespace is PSA-restricted.
+func TestHandleWorkflowApply_HardenedSpecPassesRestrictedNs(t *testing.T) {
+	client := newPSATestClient(restrictedNs("secure-ns"))
+	ctx := context.Background()
+
+	result, err := handleWorkflowApply(ctx, client, WorkflowApplyParams{
+		Namespace: "secure-ns",
+		Name:      "my-hardened-app",
+		Manifests: []map[string]any{hardenedDeployManifest("my-hardened-app")},
+	})
+	if err != nil {
+		t.Fatalf("expected hardened spec to pass restricted PSA, got error: %v", err)
+	}
+	if result.Created != 1 {
+		t.Errorf("expected 1 created resource, got %d", result.Created)
+	}
+}
+
+// TestHandleWorkflowApply_BareSpecPassesAfterPSACompliance verifies that a bare
+// Deployment (no security context) is accepted on a restricted namespace because
+// ensurePSACompliance injects all required fields before ValidatePSA runs.
+func TestHandleWorkflowApply_BareSpecPassesAfterPSACompliance(t *testing.T) {
+	client := newPSATestClient(restrictedNs("secure-ns2"))
+	ctx := context.Background()
+
+	result, err := handleWorkflowApply(ctx, client, WorkflowApplyParams{
+		Namespace: "secure-ns2",
+		Name:      "bare-app",
+		Manifests: []map[string]any{bareDeployManifest("bare-app")},
+	})
+	if err != nil {
+		t.Fatalf("ensurePSACompliance should have injected required fields before validation: %v", err)
+	}
+	if result.Created != 1 {
+		t.Errorf("expected 1 created, got %d", result.Created)
+	}
+}
+
+// TestHandleWorkflowApply_NonCompliantSpecFailsRestrictedNs verifies that a spec
+// with allowPrivilegeEscalation=true (which ensurePSACompliance won't fix) is
+// rejected by wf_apply with a structured PSA error.
+func TestHandleWorkflowApply_NonCompliantSpecFailsRestrictedNs(t *testing.T) {
+	client := newPSATestClient(restrictedNs("secure-ns3"))
+	ctx := context.Background()
+
+	_, err := handleWorkflowApply(ctx, client, WorkflowApplyParams{
+		Namespace: "secure-ns3",
+		Name:      "bad-app",
+		Manifests: []map[string]any{nonCompliantDeployManifest("bad-app")},
+	})
+	if err == nil {
+		t.Fatal("expected PSA validation error for non-compliant spec, got nil")
+	}
+	if !strings.Contains(err.Error(), "PSA validation failed") {
+		t.Errorf("error should indicate PSA validation failure, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "allowPrivilegeEscalation") {
+		t.Errorf("error should mention allowPrivilegeEscalation, got: %v", err)
+	}
+}
+
+// TestHandleWorkflowApply_NonCompliantSpecPassesPrivilegedNs verifies that a
+// non-compliant spec (allowPrivilegeEscalation=true) is accepted in a privileged
+// namespace where PSA validation is skipped.
+func TestHandleWorkflowApply_NonCompliantSpecPassesPrivilegedNs(t *testing.T) {
+	client := newPSATestClient(privilegedNs("priv-ns"))
+	ctx := context.Background()
+
+	result, err := handleWorkflowApply(ctx, client, WorkflowApplyParams{
+		Namespace: "priv-ns",
+		Name:      "any-app",
+		Manifests: []map[string]any{nonCompliantDeployManifest("any-app")},
+	})
+	if err != nil {
+		t.Fatalf("privileged namespace should skip PSA validation, got error: %v", err)
+	}
+	if result.Created != 1 {
+		t.Errorf("expected 1 created, got %d", result.Created)
+	}
+}
+
+// TestHandleWorkflowApply_PSAErrorStructured verifies that the PSA error returned
+// by wf_apply on a restricted namespace is a *k8s.PSAValidationError with
+// individual violation entries for each missing field.
+func TestHandleWorkflowApply_PSAErrorStructured(t *testing.T) {
+	client := newPSATestClient(restrictedNs("structured-err-ns"))
+	ctx := context.Background()
+
+	_, err := handleWorkflowApply(ctx, client, WorkflowApplyParams{
+		Namespace: "structured-err-ns",
+		Name:      "bad-app",
+		Manifests: []map[string]any{nonCompliantDeployManifest("bad-app")},
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var psaErr *k8s.PSAValidationError
+	if !errors.As(err, &psaErr) {
+		t.Fatalf("expected *k8s.PSAValidationError, got %T: %v", err, err)
+	}
+	if psaErr.Namespace != "structured-err-ns" {
+		t.Errorf("PSAValidationError.Namespace: got %q, want %q", psaErr.Namespace, "structured-err-ns")
+	}
+	if psaErr.Level != "restricted" {
+		t.Errorf("PSAValidationError.Level: got %q, want %q", psaErr.Level, "restricted")
+	}
+	if len(psaErr.Violations) == 0 {
+		t.Error("expected at least one violation in PSAValidationError")
+	}
+}


### PR DESCRIPTION
## Summary

- Closes #115
- Adds pre-flight PSA validation to `wf_apply` that fires after `ensurePSACompliance` injects defaults, but before calling the Kubernetes API server
- Returns a structured `*PSAValidationError` listing every failing field separately, so callers can fix their spec without a 60-second timeout and a misleading "Deployed" message
- Validation is scoped to restricted/baseline namespaces; privileged namespaces and namespaces with no enforce label are skipped entirely

## What changed

**`pkg/k8s/psa.go`** (new file):
- `NamespacePSALevel` — fetches `pod-security.kubernetes.io/enforce` label from the namespace, returns `"privileged"` when absent
- `ValidatePSA` — checks Deployment, Job, and CronJob manifests against four restricted-PSA requirements per container: `runAsNonRoot`, `allowPrivilegeEscalation: false`, `capabilities.drop: ALL`, `seccompProfile.type: RuntimeDefault|Localhost`
- `PSAValidationError` — structured error with `Namespace`, `Level`, and `[]PSAViolation` so callers can iterate per-field violations

**`pkg/tools/deploy.go`** (modified):
- Added PSA level lookup + `ValidatePSA` call in `handleWorkflowApply`, after `ensurePSACompliance` and before GVR resolution and apply

**Design choices:**
- Image `Config.User` inspection skipped; callers must set explicit `runAsNonRoot` — YAGNI comment in place
- Validation runs on the post-`ensurePSACompliance` spec, so bare manifests that get all required fields injected automatically still pass
- The only way to get a PSA error is to explicitly set a field to a non-compliant value (e.g., `allowPrivilegeEscalation: true`), since `setIfAbsent` won't override user-specified values

## Test plan

- [x] `go test ./pkg/...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -c -tags integration ./test/integration/` — compiles cleanly
- [x] Unit tests in `pkg/k8s/psa_test.go`: privileged skip, hardened pass, each missing field produces named violation, pod-level fields satisfy container requirements, Job kind validated, error format includes namespace/level/each field
- [x] Tools-level tests in `pkg/tools/deploy_psa_test.go`: hardened spec passes restricted NS, bare spec passes (ensurePSACompliance fills fields), explicitly non-compliant spec fails restricted NS, non-compliant spec passes privileged NS, error type is `*PSAValidationError` with namespace+level+violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)