### PR TITLE
fix(enclave_list): exclude Terminating namespaces from results

### DIFF
--- a/pkg/tools/enclave.go
+++ b/pkg/tools/enclave.go
@@ -504,6 +504,14 @@ func handleEnclaveList(ctx context.Context, client *k8s.Client, _ *authz.Evaluat
 
 	items := make([]EnclaveListItem, 0)
 	for _, ns := range namespaces {
+		// Skip terminating namespaces — enclave_deprovision triggers deletion
+		// but the namespace lingers in Terminating phase until all finalizers
+		// clear. Returning them confuses callers (Chroma, Kraken) that expect
+		// only active enclaves.
+		if ns.Status.Phase == "Terminating" {
+			continue
+		}
+
 		ann := ns.Annotations
 		if ann == nil {
 			ann = map[string]string{}


### PR DESCRIPTION
## Summary

- `enclave_list` was returning namespaces in `Terminating` phase. After `enclave_deprovision` fires, the namespace enters `Terminating` and stays there for minutes while finalizers clear. Callers (Chroma, Kraken) saw the enclave as still active during this window.
- Filter out `ns.Status.Phase == "Terminating"` in `handleEnclaveList` so only live enclaves are returned.

## Impact

- Chroma home page no longer shows a deprovisioned enclave after deletion is triggered
- E2E scenario E5 (remove channel as enclave) chromaAssertion can now pass within its 5-minute polling window

## Test plan

- [ ] `go build ./pkg/tools/...` — compiles clean
- [ ] Deprovision an enclave, confirm `enclave_list` no longer returns it while namespace is terminating
- [ ] E2E E5 scenario passes in run 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)