### PR TITLE
fix(chart): default trustedAZPs to "thekraken,tntc"

### DIFF
--- a/charts/tentacular-mcp/values.yaml
+++ b/charts/tentacular-mcp/values.yaml
@@ -142,8 +142,11 @@ exoskeletonAuth:
   # Required keys: issuer-url, client-id, client-secret.
   existingSecret: ""
   # -- Comma-separated list of additional OIDC client IDs whose tokens
-  # are accepted (e.g. "thekraken" for service-to-service auth).
-  trustedAZPs: ""
+  # are accepted. Defaults to "thekraken,tntc" so the Slack bot and CLI
+  # (the first-party clients that authenticate users against MCP) work out
+  # of the box. Override with a different list when additional or different
+  # clients need to be trusted.
+  trustedAZPs: "thekraken,tntc"
 
 # -- Exoskeleton configuration for backing-service registration.
 exoskeleton:

--- a/charts/tentacular-platform/values.yaml
+++ b/charts/tentacular-platform/values.yaml
@@ -225,9 +225,12 @@ exoskeletonAuth:
   # -- OIDC client secret
   clientSecret: ""
   # -- Additional OIDC client IDs whose tokens the MCP server will accept.
-  # The clientID above is always trusted. Add other clients (e.g. "thekraken")
-  # as a comma-separated list when multiple services share the same Keycloak realm.
-  trustedAZPs: ""
+  # The clientID above is always trusted. Defaults to "thekraken,tntc" so
+  # tokens from the Slack bot and CLI are accepted out of the box — these
+  # are the first-party clients that authenticate users against MCP.
+  # Override with a different comma-separated list when additional or
+  # different clients need to be trusted.
+  trustedAZPs: "thekraken,tntc"
 
 # -- esm-sh module proxy configuration
 esm-sh:


### PR DESCRIPTION
## Summary

- Chart default for `exoskeletonAuth.trustedAZPs` was an empty string. MCP's OIDC validator only trusted its own clientID (`tentacular-mcp`), so user tokens from `thekraken` and `tntc` got rejected with "invalid token".
- Defaulting to `"thekraken,tntc"` makes the two first-party clients work out of the box — they're the only services that auth users against MCP.

## Why

During the 2026-05-25 nats-weu rc.34 deploy, re-rendering the chart cleared a hand-patched Secret value and broke every MCP call from both the Slack bot and the CLI. Putting the canonical value in the chart default prevents this from recurring on future cluster deploys.

## Test plan

- [ ] `helm template tentacular-platform` produces `TENTACULAR_KEYCLOAK_TRUSTED_AZPS: "thekraken,tntc"` in the exoskeleton-config Secret
- [ ] MCP startup log shows `"trusted_azps": 3` (self + thekraken + tntc)
- [ ] Validate on nats-weu in next deploy: Kraken returns real cluster data (not "401 invalid token") when asked about tentacle status

🤖 Generated with [Claude Code](https://claude.com/claude-code)